### PR TITLE
config fixes: import legacy, save as JSON

### DIFF
--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -119,6 +119,9 @@ def restore():
 def main():
     cli_args = parse_command_line()
 
+    # Initialize logging.
+    initialize_logging(logging.WARNING)
+
     die_if_running()
     die_if_root()
 
@@ -132,16 +135,16 @@ def main():
         config_file = config.LEGACY_CONFIG_FILE
     config.set_config_env(config_file)
 
+    # Parse CLI args and update affected config vars.
+    parse_args(cli_args)
+
     # Update logging level from config.
     logger = logging.getLogger()
     logger.setLevel(config.LOG_LEVEL)
 
-    parse_args(cli_args)
-
     if config.DELETE_INSTALL_LOG and os.path.isfile(config.LOGOS_LOG):
         os.remove(config.LOGOS_LOG)
-    initialize_logging(config.LOG_LEVEL)
-
+    
     # If Logos app is installed, run the desired Logos action.
     if config.LOGOS_EXE is not None and os.access(config.LOGOS_EXE, os.X_OK):
         if config.ACTION == 'control':

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -147,10 +147,13 @@ def main():
     config.get_env_config()
 
     if config.DELETE_INSTALL_LOG and os.path.isfile(config.LOGOS_LOG):
-        os.remove(config.LOGOS_LOG)
+        # Write empty file before continuing.
+        with open(config.LOGOS_LOG, 'w') as f:
+            f.write('')
 
     # If Logos app is installed, run the desired Logos action.
     if config.LOGOS_EXE is not None and os.access(config.LOGOS_EXE, os.X_OK):
+        logging.info(f"App is installed: {config.LOGOS_EXE}")
         if config.ACTION == 'control':
             run_control_panel()
             sys.exit(0)

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -26,6 +26,7 @@ from utils import getDialog
 from utils import set_appimage
 from utils import set_default_config
 from utils import setDebug
+from utils import write_config
 from wine import run_indexing
 from wine import run_logos
 from wine import run_winetricks
@@ -130,10 +131,11 @@ def main():
     # Update config from CONFIG_FILE.
     # FIXME: This means that values in CONFIG_FILE take precedence over env variables.
     #   Is this preferred, or should env variables take precedence over CONFIG_FILE?
-    config_file = config.CONFIG_FILE
-    if file_exists(config.LEGACY_CONFIG_FILE):
-        config_file = config.LEGACY_CONFIG_FILE
-    config.set_config_env(config_file)
+    if not file_exists(config.CONFIG_FILE) and file_exists(config.LEGACY_CONFIG_FILE):
+        config.set_config_env(config.LEGACY_CONFIG_FILE)
+        write_config(config.CONFIG_FILE)
+    else:
+        config.set_config_env(config.CONFIG_FILE)
 
     # Parse CLI args and update affected config vars.
     parse_args(cli_args)

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -15,6 +15,7 @@ from installer import install
 from msg import cli_msg
 from msg import initialize_logging
 from msg import logos_error
+from msg import update_log_level
 from utils import checkDependencies
 from utils import curses_menu
 from utils import die_if_root
@@ -121,7 +122,7 @@ def main():
     cli_args = parse_command_line()
 
     # Initialize logging.
-    initialize_logging(logging.WARNING)
+    initialize_logging(config.LOG_LEVEL)
 
     die_if_running()
     die_if_root()
@@ -140,13 +141,12 @@ def main():
     # Parse CLI args and update affected config vars.
     parse_args(cli_args)
 
-    # Update logging level from config.
-    logger = logging.getLogger()
-    logger.setLevel(config.LOG_LEVEL)
-
     if config.DELETE_INSTALL_LOG and os.path.isfile(config.LOGOS_LOG):
         os.remove(config.LOGOS_LOG)
-    
+
+    # Set terminal log level based on current config.
+    update_log_level(config.LOG_LEVEL)
+
     # If Logos app is installed, run the desired Logos action.
     if config.LOGOS_EXE is not None and os.access(config.LOGOS_EXE, os.X_OK):
         if config.ACTION == 'control':

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -130,8 +130,6 @@ def main():
     # Set initial config; incl. defining CONFIG_FILE.
     set_default_config()
     # Update config from CONFIG_FILE.
-    # FIXME: This means that values in CONFIG_FILE take precedence over env variables.
-    #   Is this preferred, or should env variables take precedence over CONFIG_FILE?
     if not file_exists(config.CONFIG_FILE) and file_exists(config.LEGACY_CONFIG_FILE):
         config.set_config_env(config.LEGACY_CONFIG_FILE)
         write_config(config.CONFIG_FILE)
@@ -141,11 +139,15 @@ def main():
     # Parse CLI args and update affected config vars.
     parse_args(cli_args)
 
+    # Set terminal log level based on CLI config.
+    cli_log_level = config.LOG_LEVEL
+    update_log_level(config.LOG_LEVEL)
+
+    # Re-read environment variables.
+    config.get_env_config()
+
     if config.DELETE_INSTALL_LOG and os.path.isfile(config.LOGOS_LOG):
         os.remove(config.LOGOS_LOG)
-
-    # Set terminal log level based on current config.
-    update_log_level(config.LOG_LEVEL)
 
     # If Logos app is installed, run the desired Logos action.
     if config.LOGOS_EXE is not None and os.access(config.LOGOS_EXE, os.X_OK):

--- a/config.py
+++ b/config.py
@@ -135,3 +135,10 @@ def set_config_env(config_file_path):
     logging.info(f"Setting {len(config_dict)} variables from config file.")
     for key, value in config_dict.items():
         globals()[key] = value
+
+def get_env_config():
+    for var in globals().keys():
+        val = os.getenv(var)
+        if val is not None:
+            logging.info(f"Setting '{var}' to '{val}'")
+            globals()[var] = val

--- a/config.py
+++ b/config.py
@@ -104,7 +104,7 @@ def get_config_file_dict(config_file_path):
             return None
         except FileNotFoundError:
             logging.info(f"No config file not found at {config_file_path}")
-            return None
+            return config_dict
         except json.JSONDecodeError as e:
             logging.error(f"Config file could not be read.")
             logging.error(e)

--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ CUSTOMBINPATH = os.getenv('CUSTOMBINPATH')
 DEBUG = os.getenv('DEBUG', False)
 DELETE_INSTALL_LOG = os.getenv('DELETE_INSTALL_LOG', False)
 DIALOG = os.getenv('DIALOG')
+LEGACY_CONFIG_FILE = os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.conf")
 LOGOS_LOG = os.getenv('LOGOS_LOG', os.path.expanduser("~/.local/state/Logos_on_Linux/install.log"))
 LOGOS_VERSION = os.getenv('LOGOS_VERSION')
 LOGOS64_MSI = os.getenv('LOGOS64_MSI')
@@ -48,7 +49,7 @@ WINETRICKS_UNATTENDED = os.getenv('WINETRICKS_UNATTENDED')
 # Other run-time variables.
 ACTION = 'app'
 APPIMAGE_LINK_SELECTION_NAME = "selected_wine.AppImage"
-DEFAULT_CONFIG_PATH = os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.conf")
+DEFAULT_CONFIG_PATH = os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.json")
 EXTRA_INFO = "The following packages are usually necessary: winbind cabextract libjpeg8."
 GUI = None
 LOGOS_FORCE_ROOT = False
@@ -79,26 +80,38 @@ PACKAGE_MANAGER_COMMAND = None
 PACKAGES = None
 SUPERUSER_COMMAND = None
 
+persistent_config_keys = [
+    "FLPRODUCT", "FLPRODUCTi", "TARGETVERSION", "INSTALLDIR", "APPDIR",
+    "APPDIR_BINDIR", "WINETRICKSBIN", "WINEPREFIX", "WINEBIN_CODE", "WINE_EXE",
+    "WINESERVER_EXE", "WINE64_APPIMAGE_FULL_URL", "WINECMD_ENCODING",
+    "WINE64_APPIMAGE_FULL_FILENAME", "APPIMAGE_LINK_SELECTION_NAME",
+    "LOGOS_EXECUTABLE", "LOGOS_EXE", "LOGOS_DIR", "LOGS", "BACKUPDIR"
+]
 
 def get_config_file_dict(config_file_path):
     config_dict = {}
-    try:
-        with open(config_file_path, 'r') as config_file:
-            cfg = json.load(config_file)
+    if config_file_path.endswith('.json'):
+        try:
+            with open(config_file_path, 'r') as config_file:
+                cfg = json.load(config_file)
 
-        for key, value in cfg.items():
-            config_dict[key] = value
-        return config_dict
-    except TypeError as e:
-        logging.error(f"Error opening Config file: {e}")
-        return None
-    except FileNotFoundError:
-        # Most likely a new install with no saved config file yet.
-        logging.info(f"No config file not found at {config_file_path}")
-        return None
-    except json.JSONDecodeError:
-        # Probably legacy config for bash script.
-        logging.info("Converting from legacy config file.")
+            for key, value in cfg.items():
+                config_dict[key] = value
+            return config_dict
+        except TypeError as e:
+            logging.error(f"Error opening Config file.")
+            logging.error(e)
+            return None
+        except FileNotFoundError:
+            logging.info(f"No config file not found at {config_file_path}")
+            return None
+        except json.JSONDecodeError as e:
+            logging.error(f"Config file could not be read.")
+            logging.error(e)
+            return None
+    elif config_file_path.endswith('.conf'):
+        # Legacy config from bash script.
+        logging.info("Reading from legacy config file.")
         with open(config_file_path, 'r') as config_file:
             for line in config_file:
                 line = line.strip()
@@ -113,12 +126,12 @@ def get_config_file_dict(config_file_path):
                     if len(vparts) > 1:
                         value = vparts[0].strip().strip('"').strip("'")
                     config_dict[parts[0]] = value
-
         return config_dict
 
 def set_config_env(config_file_path):
     config_dict = get_config_file_dict(config_file_path)
     if config_dict is None:
         logos_error(f"Error: Unable to get config at {config_file_path}")
+    logging.info(f"Setting {len(config_dict)} variables from config file.")
     for key, value in config_dict.items():
         globals()[key] = value

--- a/installer.py
+++ b/installer.py
@@ -413,7 +413,7 @@ def postInstall(app):
             logging.info(f"Comparing its contents with current config.")
             current_config_file_dict = config.get_config_file_dict(config.CONFIG_FILE)
             different = False
-            for key in config_keys:
+            for key in config.persistent_config_keys:
                 if current_config_file_dict.get(key) != config.__dict__.get(key):
                     different = True
                     break

--- a/installer.py
+++ b/installer.py
@@ -389,16 +389,9 @@ def postInstall(app):
         app.root.event_generate("<<UpdateInstallText>>")
 
     HOME = os.environ.get('HOME')
-    config_keys = [
-        "FLPRODUCT", "FLPRODUCTi", "TARGETVERSION", "INSTALLDIR", "APPDIR",
-        "APPDIR_BINDIR", "WINETRICKSBIN", "WINEPREFIX", "WINEBIN_CODE", "WINE_EXE",
-        "WINESERVER_EXE", "WINE64_APPIMAGE_FULL_URL", "WINECMD_ENCODING",
-        "WINE64_APPIMAGE_FULL_FILENAME", "APPIMAGE_LINK_SELECTION_NAME",
-        "LOGOS_EXECUTABLE", "LOGOS_EXE", "LOGOS_DIR", "LOGS", "BACKUPDIR"
-    ]
 
     logging.debug("post-install config:")
-    for k in config_keys:
+    for k in config.persistent_config_keys:
         logging.debug(f"{k}: {config.__dict__.get(k)}")
 
     if os.path.isfile(config.LOGOS_EXE):
@@ -410,7 +403,7 @@ def postInstall(app):
             logging.info(f"No config file at {config.CONFIG_FILE}")
             os.makedirs(os.path.join(HOME, ".config", "Logos_on_Linux"), exist_ok=True)
             if os.path.isdir(os.path.join(HOME, ".config", "Logos_on_Linux")):
-                write_config(config.CONFIG_FILE, config_keys)
+                write_config(config.CONFIG_FILE)
                 logging.info(f"A config file was created at {config.CONFIG_FILE}.")
             else:
                 logos_warn(f"{HOME}/.config/Logos_on_Linux does not exist. Failed to create config file.")
@@ -426,7 +419,7 @@ def postInstall(app):
                     break
             if different is True and logos_acknowledge_question(f"Update config file at {config.CONFIG_FILE}?", "The existing config file was not overwritten."):
                 logging.info(f"Updating config file.")
-                write_config(config.CONFIG_FILE, config_keys)
+                write_config(config.CONFIG_FILE)
         else:
             # Script was run with a config file. Skip modifying the config.
             pass

--- a/msg.py
+++ b/msg.py
@@ -6,6 +6,21 @@ import sys
 import config
 
 
+def get_log_level_name(level):
+    name = None
+    levels = {
+        "CRITICAL": logging.CRITICAL,
+        "ERROR": logging.ERROR,
+        "WARNING": logging.WARNING,
+        "INFO": logging.INFO,
+        "DEBUG": logging.DEBUG,
+    }
+    for k, v in levels.items():
+        if level == v:
+            name = k
+            break
+    return name
+
 def initialize_logging(stderr_log_level):
     '''
     Log levels:
@@ -39,6 +54,13 @@ def initialize_logging(stderr_log_level):
         handlers=handlers,
     )
     cli_msg(f"Installer log file: {config.LOGOS_LOG}")
+
+def update_log_level(new_level):
+    # Update logging level from config.
+    for h in logging.getLogger().handlers:
+        if type(h) == logging.StreamHandler:
+            h.setLevel(new_level)
+    logging.info(f"Terminal log level set to {get_log_level_name(new_level)}")
 
 def cli_msg(message, end='\n'):
     ''' Used for messages that should be printed to stdout regardless of log level. '''

--- a/utils.py
+++ b/utils.py
@@ -130,10 +130,11 @@ def set_default_config():
     config.MYDOWNLOADS = get_user_downloads_dir()
     os.makedirs(os.path.dirname(config.LOGOS_LOG), exist_ok=True)
 
-def write_config(config_file_path, config_keys=None):
+def write_config(config_file_path):
+    logging.info(f"Writing config to {config_file_path}")
     os.makedirs(os.path.dirname(config_file_path), exist_ok=True)
 
-    config_data = {key: config.__dict__.get(key) for key in config_keys}
+    config_data = {key: config.__dict__.get(key) for key in config.persistent_config_keys}
 
     try:
         with open(config_file_path, 'w') as config_file:


### PR DESCRIPTION
Rather than log an error and exit if the config file can't be decoded as JSON, assume that it is a plaintext legacy config file. Read it line-by-line, assuming the key/value separator is '='.

I added an if statement (L112-L114) to remove any comments found *after* the `key=value` text, like `key=value # comment`, but maybe that's an unlikely (or even impossible) scenario?

This doesn't fully close #6, since there is a bigger discussion going on there, but it would at least remove the roadblock to proper script execution.