### PR TITLE
Add an Option to Reinstall Dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+- 4.0.0-alpha.2
+	- Fix #3 [T. H. Wright]
+	- Fix #4 [T. H. Wright]
+	- Fix #6 [N. Marti]
 - 4.0.0-alpha.1
-	- #9 [N. Marti]
- 	- #10 [N. Marti]
+	- Fix #9 [N. Marti]
+ 	- Fix #10 [N. Marti]
   	- Add initial .github/workflows [N. Marti]
 - 4.0.0-alpha
 	- Migrate repository to FaithLife Community organization

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -246,7 +246,6 @@ def main():
                 switch_logging()
             else:
                 logos_error("Unknown menu choice.")
-
     sys.exit(0)
 # END FUNCTION DECLARATIONS
 

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -17,7 +17,7 @@ from msg import cli_msg
 from msg import initialize_logging
 from msg import logos_error
 from msg import update_log_level
-from utils import checkDependencies
+from utils import check_dependencies
 from utils import curses_menu
 from utils import die_if_root
 from utils import die_if_running
@@ -81,7 +81,8 @@ def parse_args(args):
         config.LOGOS_FORCE_ROOT = True
 
     if args.reinstall_dependencies:
-        config.REINSTALL_DEPENDENCIES = True
+        check_dependencies()
+        sys.exit(0)
 
     if args.get_winetricks: 
        setWinetricks()
@@ -229,7 +230,7 @@ def main():
             elif choice == "Edit Config":
                 edit_config()
             elif choice == "Reinstall Dependencies":
-                checkDependencies()
+                check_dependencies()
             elif choice == "Back up Data":
                 backup()
             elif choice == "Restore Data":

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from installer import finish_install
 from installer import logos_setup
 from installer import setWinetricks
 from msg import cli_msg
-from utils import checkDependencies
+from utils import check_dependencies
 from utils import get_winebin_code_and_desc
 from utils import getLogosReleases
 from utils import getWineBinOptions
@@ -481,7 +481,6 @@ class ControlWindow(ControlGui):
         
         self.config_button.config(command=self.open_config)
         self.deps_button.config(command=self.reinstall_deps)
-        self.deps_button.state(['disabled']) # FIXME: needs function
         self.getwinetricks_button.config(command=self.get_winetricks)
         self.runwinetricks_button.config(command=self.launch_winetricks)
         self.message_event = '<<ClearMessage>>'
@@ -511,7 +510,7 @@ class ControlWindow(ControlGui):
         self.installdir_filechooser.config(text=self.installdir)
 
     def reinstall_deps(self, evt=None):
-        checkDependencies()
+        check_dependencies()
 
     def get_winetricks(self, evt=None):
         winetricks_status = setWinetricks()

--- a/config.py
+++ b/config.py
@@ -50,7 +50,6 @@ WINETRICKS_UNATTENDED = os.getenv('WINETRICKS_UNATTENDED')
 ACTION = 'app'
 APPIMAGE_LINK_SELECTION_NAME = "selected_wine.AppImage"
 DEFAULT_CONFIG_PATH = os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.json")
-EXTRA_INFO = "The following packages are usually necessary: winbind cabextract libjpeg8."
 GUI = None
 LOGOS_FORCE_ROOT = False
 LOGOS_ICON_FILENAME = None
@@ -76,7 +75,8 @@ WORKDIR = tempfile.mkdtemp(prefix="/tmp/LBS.")
 
 OS_NAME = None
 OS_RELEASE = None
-PACKAGE_MANAGER_COMMAND = None
+PACKAGE_MANAGER_COMMAND_INSTALL = None
+PACKAGE_MANAGER_COMMAND_QUERY = None
 PACKAGES = None
 SUPERUSER_COMMAND = None
 

--- a/installer.py
+++ b/installer.py
@@ -12,9 +12,7 @@ from msg import logos_acknowledge_question
 from msg import logos_error
 from msg import logos_warn
 from utils import check_libs
-from utils import checkDependencies
-from utils import checkDependenciesLogos9
-from utils import checkDependenciesLogos10
+from utils import check_dependencies
 from utils import clean_all
 from utils import cli_download
 from utils import curses_menu
@@ -121,22 +119,19 @@ def chooseVersion():
     QUESTION_TEXT = f"Which version of {config.FLPRODUCT} should the script install?"
     if config.TARGETVERSION is None or config.TARGETVERSION == "":
         options = ["10", "9", "Exit"]
-        versionChoice = curses_menu(options, TITLE, QUESTION_TEXT)
-    else:
-        versionChoice = config.TARGETVERSION
+        version_choice = curses_menu(options, TITLE, QUESTION_TEXT)
     logging.info(f"Target version: {config.TARGETVERSION}")
 
-    checkDependencies()
-    if "10" in versionChoice:
-        checkDependenciesLogos10()
+    if "10" in version_choice:
         config.TARGETVERSION = "10"
-    elif "9" in versionChoice:
-        checkDependenciesLogos9()
+    elif "9" in version_choice:
         config.TARGETVERSION = "9"
-    elif versionChoice == "Exit.":
+    elif version_choice == "Exit.":
         sys.exit(0)
     else:
         logos_error("Unknown version. Installation canceled!", "")
+    
+    check_dependencies()
 
 def logos_setup():
     if config.LOGOS64_URL is None or config.LOGOS64_URL == "":


### PR DESCRIPTION
Fixes #3.

The install routine for dependencies was broken. I had to test this heavily on my pacman machine but I got it working.

This PR thus fixes the install dependencies routine and adds an optarg, a TUI, and a GUI to run the check_dependencies() function.

Depends on #31.