### PR TITLE
Get wine branch using mscoree.dll - Fixes #32

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -813,3 +813,11 @@ def write_progress_bar(percent, screen_width=80):
     l_y = int(l_f * percent / 100) # num. of chars. complete
     l_n  = l_f - l_y               # num. of chars. incomplete
     print(f" [{y*l_y}{n*l_n}] {percent:>3}%", end='\r') # end='\x1b[1K\r' to erase to end of line
+
+def is_appimage(file_path):
+    file_path = Path(file_path)
+    with file_path.open('rb') as f:
+        elf_sig = f.read(4)
+        _ = f.read(4)
+        ai_sig = f.read(2)
+    return elf_sig == b'\x7fELF' and ai_sig == b'AI'

--- a/wine.py
+++ b/wine.py
@@ -125,20 +125,20 @@ def wineBinaryVersionCheck(TESTBINARY):
     version_string = subprocess.check_output(cmd, encoding='utf-8').strip()
     try:
         version, release = version_string.split()
-    except ValueError: # "Stable" release isn't noted in version output
+    except ValueError: # neither "Devel" nor "Stable" release is noted in version output
         version = version_string
-        release = '(Stable)'
+        release = get_wine_branch(TESTBINARY)
 
-    ver_major = version.split('.')[0].replace('wine-', '') # remove 'wine-'
+    ver_major = version.split('.')[0].lstrip('wine-') # remove 'wine-'
     ver_minor = version.split('.')[1]
-    release = release.replace('(', '').replace(')', '') # remove parentheses
+    release = release.lstrip('(').rstrip(')').lower() # remove parentheses
 
     try:
         TESTWINEVERSION = [int(ver_major), int(ver_minor), release]
     except ValueError:
         return False, "Couldn't determine wine version."
 
-    if TESTWINEVERSION[2] == 'Stable':
+    if TESTWINEVERSION[2] == 'stable':
         return False, "Can't use Stable release"
     elif TESTWINEVERSION[0] < 7:
         return False, "Version is < 7.0"
@@ -146,7 +146,7 @@ def wineBinaryVersionCheck(TESTBINARY):
         if "Proton" in TESTBINARY or ("Proton" in os.path.realpath(TESTBINARY) if os.path.islink(TESTBINARY) else False):
             if TESTWINEVERSION[1] == 0:
                 return True, "None"
-        elif release != 'Staging':
+        elif release != 'staging':
             return False, "Needs to be Staging release"
         elif TESTWINEVERSION[1] < WINE_MINIMUM[1]:
             reason = f"{'.'.join(TESTWINEVERSION)} is below minimum required, {'.'.join(WINE_MINIMUM)}"
@@ -155,7 +155,7 @@ def wineBinaryVersionCheck(TESTBINARY):
         if TESTWINEVERSION[1] < 1:
             return False, "Version is 8.0"
         elif TESTWINEVERSION[1] < 16:
-            if release != 'Staging':
+            if release != 'staging':
                 return False, "Version < 8.16 needs to be Staging release"
 
     return True, "None"


### PR DESCRIPTION
## Fixes #32
For system (non-AppImage) wine, `mscoree.dll` is assumed to be relative to the wine binary:
```
wine64/../../lib64/wine/x86_64-windows/mscoree.dll
```
For AppImage wine, it's found by mounting the AppImage, then glob searching for `**/lib64/**/mscoree.dll`.
The AppImage must be Type 2 (see [AppImage spec](https://docs.appimage.org/reference/specification.html#development) and [draft.md](https://github.com/AppImage/AppImageSpec/blob/master/draft.md))
This has been tested with winehq-stable branch and with the current preferred AppImage found at https://github.com/FaithLife-Community/LogosLinuxInstaller/releases/download/wine-devel-8.19/wine-devel_8.19-x86_64.AppImage
However, I don't think the AppImage's branch is ever actually checked in the script at this point. I'll leave that check for a future PR.

## Testing
### wine64 found in PATH
```python
$ python -c 'import config, logging, wine; logging.basicConfig(level=logging.INFO); config.TARGETVERSION="10"; wine.createWineBinaryList()'
INFO:root:Determining wine branch of '/usr/bin/wine64'
INFO:root:'/usr/bin/wine64' resolved to '/opt/wine-stable/bin/wine64'
INFO:root:Removing binary: /usr/bin/wine64 because: Can't use Stable release
INFO:root:Determining wine branch of '/bin/wine64'
INFO:root:'/bin/wine64' resolved to '/opt/wine-stable/bin/wine64'
INFO:root:Removing binary: /bin/wine64 because: Can't use Stable release
```
### wine AppImage
```python
$ python -c 'import config, logging, wine; logging.basicConfig(level=logging.INFO); config.TARGETVERSION="10"; print(wine.wineBinaryVersionCheck("/home/nate/Téléchargements/wine-devel_8.19-x86_64.AppImage"))'
INFO:root:Determining wine branch of '/home/nate/Téléchargements/wine-devel_8.19-x86_64.AppImage'
(True, 'None')
```