### PR TITLE
Add ability to detect and remove AppImageLauncher

### DIFF
--- a/config.py
+++ b/config.py
@@ -78,13 +78,16 @@ LOGOS9_WINE64_BOTTLE_TARGZ_URL = f"https://github.com/ferion11/wine64_bottle_dot
 WINETRICKS_DOWNLOADER = "wget"
 WINETRICKS_URL = "https://raw.githubusercontent.com/Winetricks/winetricks/5904ee355e37dff4a3ab37e1573c56cffe6ce223/src/winetricks"
 WORKDIR = tempfile.mkdtemp(prefix="/tmp/LBS.")
+REBOOT_REQUIRED = None
 
 OS_NAME = None
 OS_RELEASE = None
 PACKAGE_MANAGER_COMMAND_INSTALL = None
+PACKAGE_MANAGER_COMMAND_REMOVE = None
 PACKAGE_MANAGER_COMMAND_QUERY = None
 PACKAGES = None
 L9PACKAGES = None
+BADPACKAGES = None
 SUPERUSER_COMMAND = None
 
 persistent_config_keys = [

--- a/installer.py
+++ b/installer.py
@@ -182,7 +182,6 @@ def begin_install(app=None):
 
     if config.WINEBIN_CODE:
         if config.WINEBIN_CODE.startswith("Recommended"):
-            utils.check_libs(["libfuse"])
             logging.info(f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using {config.RECOMMENDED_WINE64_APPIMAGE_FULL_VERSION} AppImage…")
             utils.make_skel(config.RECOMMENDED_WINE64_APPIMAGE_FULL_FILENAME)
             # exporting PATH to internal use if using AppImage, doing backup too:
@@ -192,7 +191,6 @@ def begin_install(app=None):
             os.chmod(f"{config.APPDIR_BINDIR}/{config.RECOMMENDED_WINE64_APPIMAGE_FULL_FILENAME}", 0o755)
             config.WINE_EXE = f"{config.APPDIR_BINDIR}/wine64"
         elif config.WINEBIN_CODE.startswith("AppImage"):
-            utils.check_libs(["libfuse"])
             logging.info(f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using the selected AppImage…")
             utils.make_skel(config.SELECTED_APPIMAGE_FILENAME)
             os.environ["OLD_PATH"] = os.environ["PATH"]


### PR DESCRIPTION
Partial fix for #5. This adds the ability to remove AppImage Launcher.

Add `config.PMC_REMOVE`; remove yum
Add `config.BADPACKAGES`
Add `query_package()` "mode" var, add `remove_packages()`, add `check_bad_packages()`

I've also made sure to add a major warning label to this remove command to its destructive capability.

One thing we may need to add is an exit function to the AppImageLauncher detection. If it is found, Logos won't be able to launch, and the install should fail at that point, otherwise we will wind up having support requests.

If the user removes it, the install should exit and instruct the user to reboot, or offer to reboot the system for the user but with warning.