### PR TITLE
Disable setappimage if winebincode != AppImage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ __pycache__/
 dist/
 build/
 env/
+.env/
 venv/
+.venv/
 .idea/

--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -203,11 +203,14 @@ def parse_args(args, parser):
         config.ACTION = control.restore
     elif args.set_appimage:
         config.APPIMAGE_FILE_PATH = args.set_appimage[0]
-        if not utils.file_exists(config.APPIMAGE_FILE_PATH):
-            raise argparse.ArgumentTypeError(f"Invalid file path: '{config.APPIMAGE_FILE_PATH}'. File does not exist.")
-        if not utils.check_appimage(config.APPIMAGE_FILE_PATH):
-            raise argparse.ArgumentTypeError(f"{config.APPIMAGE_FILE_PATH} is not an AppImage.")
-        config.ACTION = utils.set_appimage_symlink
+        if config.WINEBIN_CODE == "AppImage":
+            if not utils.file_exists(config.APPIMAGE_FILE_PATH):
+                raise argparse.ArgumentTypeError(f"Invalid file path: '{config.APPIMAGE_FILE_PATH}'. File does not exist.")
+            if not utils.check_appimage(config.APPIMAGE_FILE_PATH):
+                raise argparse.ArgumentTypeError(f"{config.APPIMAGE_FILE_PATH} is not an AppImage.")
+            config.ACTION = utils.set_appimage_symlink
+        else:
+            msg.logos_error("The command you requested is disabled. The configured install was not created using an AppImage.")
     elif args.get_winetricks:
         config.ACTION = control.get_winetricks
     elif args.run_winetricks:

--- a/gui.py
+++ b/gui.py
@@ -1,3 +1,4 @@
+from tkinter import Toplevel
 from tkinter import BooleanVar
 from tkinter import font
 from tkinter import IntVar
@@ -239,3 +240,35 @@ class ControlGui(Frame):
         s3.grid(column=0, row=12, columnspan=3, sticky='we', pady=2)
         self.message_label.grid(column=0, row=13, columnspan=3, sticky='we', pady=2)
         self.progress.grid(column=0, row=14, columnspan=3, sticky='we', pady=2)
+
+
+class ToolTip:
+    def __init__(self, widget, text):
+        self.widget = widget
+        self.text = text
+        self.tooltip_visible = False
+        self.tooltip_window = None
+
+        self.widget.bind("<Enter>", self.show_tooltip)
+        self.widget.bind("<Leave>", self.hide_tooltip)
+
+    def show_tooltip(self, event=None):
+        if not self.tooltip_visible:
+            x, y, _, _ = self.widget.bbox("insert")
+            x += self.widget.winfo_rootx() + self.widget.winfo_width() // 2 - 200
+            y += self.widget.winfo_rooty() - 25
+
+            self.tooltip_window = Toplevel(self.widget)
+            self.tooltip_window.wm_overrideredirect(True)
+            self.tooltip_window.wm_geometry(f"+{x}+{y}")
+
+            label = Label(self.tooltip_window, text=self.text, justify="left", background="#eeeeee",
+                             relief="solid", padding=4, borderwidth=1, foreground="#000000", wraplength=80)
+            label.pack(ipadx=1)
+
+            self.tooltip_visible = True
+
+    def hide_tooltip(self, event=None):
+        if self.tooltip_visible:
+            self.tooltip_window.destroy()
+            self.tooltip_visible = False

--- a/gui_app.py
+++ b/gui_app.py
@@ -465,9 +465,13 @@ class ControlWindow():
         self.gui.logging_button.state(['disabled'])
         
         self.gui.config_button.config(command=control.edit_config)
+        self.gui.deps_button.config(command=self.install_deps)
         self.gui.backup_button.config(command=self.run_backup)
         self.gui.restore_button.config(command=self.run_restore)
-        self.gui.deps_button.config(command=self.install_deps)
+        self.gui.appimage_button.config(command=self.set_appimage)
+        if config.WINEBIN_CODE != "AppImage":
+            self.gui.appimage_button.state(['disabled'])
+            gui.ToolTip(self.gui.appimage_button, "This button is disabled. The configured install was not created using an AppImage.")
         self.gui.get_winetricks_button.config(command=self.get_winetricks)
         self.gui.run_winetricks_button.config(command=self.launch_winetricks)
         self.update_run_winetricks_button()
@@ -494,6 +498,7 @@ class ControlWindow():
             self.gui.messagevar.set('Getting current app logging status...')
             self.gui.progress.state(['!disabled'])
             self.gui.progress.start()
+
 
     def run_installer(self, evt=None):
         # self.root.control_win.destroy()

--- a/gui_app.py
+++ b/gui_app.py
@@ -280,7 +280,7 @@ class InstallerWindow():
         config.SKIP_FONTS = self.gui.skip_fonts if self.gui.skip_fonts == 1 else 0
         config.SKIP_DEPENDENCIES = self.gui.skip_dependencies if self.gui.skip_dependencies == 1 else 0
         if config.LOGOS_ICON_URL is None:
-            config.LOGOS_ICON_URL = f"https://raw.githubusercontent.com/ferion11/LogosLinuxInstaller/master/img/{config.FLPRODUCTi}-128-icon.png"
+            config.LOGOS_ICON_URL = f"https://raw.githubusercontent.com/FaithLife-Community/LogosLinuxInstaller/master/img/{config.FLPRODUCTi}-128-icon.png"
         if config.LOGOS_ICON_FILENAME is None:
             config.LOGOS_ICON_FILENAME = os.path.basename(config.LOGOS_ICON_URL)
 

--- a/installer.py
+++ b/installer.py
@@ -28,12 +28,12 @@ def choose_product():
     if str(productChoice).startswith("Logos"):
         logging.info("Installing Logos Bible Software")
         config.FLPRODUCT = "Logos"
-        config.FLPRODUCTi = "logos4" #This is the variable referencing the icon path name in the repo.
+        config.FLPRODUCTi = "logos4"  # This is the variable referencing the icon path name in the repo.
         config.VERBUM_PATH = "/"
     elif str(productChoice).startswith("Verbum"):
         logging.info("Installing Verbum Bible Software")
         config.FLPRODUCT = "Verbum"
-        config.FLPRODUCTi = "verbum" #This is the variable referencing the icon path name in the repo.
+        config.FLPRODUCTi = "verbum"  # This is the variable referencing the icon path name in the repo.
         config.VERBUM_PATH = "/Verbum/"
     elif str(productChoice).startswith("Exit"):
         msg.logos_error("Exiting installation.", "")
@@ -48,10 +48,11 @@ def choose_product():
 
 
 def get_logos_release_version():
-    TITLE=f"Choose {config.FLPRODUCT} {config.TARGETVERSION} Release"
-    QUESTION_TEXT=f"Which version of {config.FLPRODUCT} {config.TARGETVERSION} do you want to install?"
+    TITLE = f"Choose {config.FLPRODUCT} {config.TARGETVERSION} Release"
+    QUESTION_TEXT = f"Which version of {config.FLPRODUCT} {config.TARGETVERSION} do you want to install?"
     if config.LOGOS_VERSION is None:
         releases = utils.get_logos_releases()
+        releases.append("Exit")
         logos_release_version = tui.menu(releases, TITLE, QUESTION_TEXT)
     else:
         logos_release_version = config.LOGOS_VERSION
@@ -63,6 +64,7 @@ def get_logos_release_version():
         config.LOGOS_RELEASE_VERSION = logos_release_version
     else:
         msg.logos_error("Failed to fetch LOGOS_RELEASE_VERSION.")
+
 
 def choose_version():
     BACKTITLE = "Choose Version Menu"
@@ -84,6 +86,7 @@ def choose_version():
         msg.logos_error("Unknown version. Installation canceled!", "")
     utils.check_dependencies()
 
+
 def logos_setup():
     if config.LOGOS64_URL is None or config.LOGOS64_URL == "":
         config.LOGOS64_URL = f"https://downloads.logoscdn.com/LBS{config.TARGETVERSION}{config.VERBUM_PATH}Installer/{config.LOGOS_RELEASE_VERSION}/{config.FLPRODUCT}-x64.msi"
@@ -94,10 +97,11 @@ def logos_setup():
         config.LOGOS_VERSION = config.LOGOS64_URL.split('/')[6]
     else:
         # This check is for someone who runs an install from a config file.
-        msg.logos_error("FLPRODUCT not set in config. Please update your config to specify either 'Logos' or 'Verbum'.", "")
+        msg.logos_error("FLPRODUCT not set in config. Please update your config to specify either 'Logos' or 'Verbum'.",
+                        "")
 
     config.LOGOS64_MSI = os.path.basename(config.LOGOS64_URL)
-    
+
     if config.INSTALLDIR is None:
         config.INSTALLDIR = f"{os.getenv('HOME')}/{config.FLPRODUCT}Bible{config.TARGETVERSION}"
     if config.APPDIR is None:
@@ -115,6 +119,7 @@ def logos_setup():
     for k, v in variables.items():
         logging.debug(f"{k}: {v}")
 
+
 def choose_install_method():
     if config.WINEPREFIX is None:
         config.WINEPREFIX = os.path.join(config.APPDIR, "wine64_bottle")
@@ -123,9 +128,9 @@ def choose_install_method():
         logging.info("Creating binary list.")
         WINEBIN_OPTIONS = utils.get_wine_options(utils.find_appimage_files(), utils.find_wine_binary_files())
 
-        BACKTITLE="Choose Wine Binary Menu"
-        TITLE="Choose Wine Binary"
-        QUESTION_TEXT=f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.LOGOS_VERSION} in {config.INSTALLDIR}?"
+        BACKTITLE = "Choose Wine Binary Menu"
+        TITLE = "Choose Wine Binary"
+        QUESTION_TEXT = f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.LOGOS_VERSION} in {config.INSTALLDIR}?"
 
         installationChoice = tui.menu(WINEBIN_OPTIONS, TITLE, QUESTION_TEXT)
         config.WINEBIN_CODE = installationChoice[0]
@@ -144,6 +149,7 @@ def choose_install_method():
     for k, v in variables.items():
         logging.debug(f"{k}: {v}")
 
+
 def check_existing_install(app=None):
     message = "Checking for existing installation..."
     msg.cli_msg(message)
@@ -157,16 +163,19 @@ def check_existing_install(app=None):
         drive_c = f"{config.WINEPREFIX}/drive_c"
         names = ['Logos.exe', 'Verbum.exe']
         if os.path.isdir(drive_c) and any(glob.glob(f"{drive_c}/**/{n}", recursive=True) for n in names):
-            msg.logos_error(f"An install was found at {config.INSTALLDIR}. Please remove/rename it or use another location by setting the INSTALLDIR variable.")
+            msg.logos_error(
+                f"An install was found at {config.INSTALLDIR}. Please remove/rename it or use another location by setting the INSTALLDIR variable.")
             return True
         else:
-            msg.logos_error(f"A directory exists at {config.INSTALLDIR}. Please remove/rename it or use another location by setting the INSTALLDIR variable.")
+            msg.logos_error(
+                f"A directory exists at {config.INSTALLDIR}. Please remove/rename it or use another location by setting the INSTALLDIR variable.")
             return True
     else:
         logging.info(f"Installing to an empty directory at {config.INSTALLDIR}.")
 
     if app is not None:
         app.root.event_generate("<<CheckExistingInstallDone>>")
+
 
 def begin_install(app=None):
     message = "Preparing installation folder..."
@@ -182,7 +191,8 @@ def begin_install(app=None):
 
     if config.WINEBIN_CODE:
         if config.WINEBIN_CODE.startswith("Recommended"):
-            logging.info(f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using {config.RECOMMENDED_WINE64_APPIMAGE_FULL_VERSION} AppImage…")
+            logging.info(
+                f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using {config.RECOMMENDED_WINE64_APPIMAGE_FULL_VERSION} AppImage…")
             utils.make_skel(config.RECOMMENDED_WINE64_APPIMAGE_FULL_FILENAME)
             # exporting PATH to internal use if using AppImage, doing backup too:
             os.environ["OLD_PATH"] = os.environ["PATH"]
@@ -202,7 +212,8 @@ def begin_install(app=None):
             os.chmod(f"{config.SELECTED_APPIMAGE_FILENAME}", 0o755)
             config.WINE_EXE = f"{config.APPDIR_BINDIR}/wine64"
         elif config.WINEBIN_CODE in ["System", "Proton", "PlayOnLinux", "Custom"]:
-            logging.info(f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using a {config.WINEBIN_CODE} WINE64 binary…")
+            logging.info(
+                f"Installing {config.FLPRODUCT} Bible {config.TARGETVERSION} using a {config.WINEBIN_CODE} WINE64 binary…")
             utils.make_skel("none.AppImage")
         else:
             msg.logos_error("WINEBIN_CODE error. Installation canceled!")
@@ -221,10 +232,12 @@ def begin_install(app=None):
         else:
             msg.logos_error(f"{wineserver_path} not found. Please either add it or create a symlink to it, and rerun.")
 
+
 def download_winetricks():
     msg.cli_msg("Downloading winetricks…")
     utils.logos_reuse_download(config.WINETRICKS_URL, "winetricks", config.APPDIR_BINDIR)
     os.chmod(f"{config.APPDIR_BINDIR}/winetricks", 0o755)
+
 
 def set_winetricks():
     msg.cli_msg("Preparing winetricks…")
@@ -259,7 +272,8 @@ def set_winetricks():
                         msg.cli_msg("Installation canceled!")
                         sys.exit(0)
             else:
-                msg.cli_msg("The system's winetricks is too old. Downloading an up-to-date winetricks from the Internet...")
+                msg.cli_msg(
+                    "The system's winetricks is too old. Downloading an up-to-date winetricks from the Internet...")
                 download_winetricks()
                 config.WINETRICKSBIN = os.path.join(config.APPDIR_BINDIR, "winetricks")
                 return 0
@@ -270,27 +284,31 @@ def set_winetricks():
             return 0
     return 0
 
+
 # This function is for Logos 9.
 def get_premade_wine_bottle():
     msg.cli_msg("Installing pre-made wineBottle 64bits…")
     logging.info(f"Downloading {config.LOGOS9_WINE64_BOTTLE_TARGZ_URL} to {config.WORKDIR}")
-    utils.logos_reuse_download(config.LOGOS9_WINE64_BOTTLE_TARGZ_URL, config.LOGOS9_WINE64_BOTTLE_TARGZ_NAME, config.WORKDIR)
+    utils.logos_reuse_download(config.LOGOS9_WINE64_BOTTLE_TARGZ_URL, config.LOGOS9_WINE64_BOTTLE_TARGZ_NAME,
+                               config.WORKDIR)
     msg.cli_msg(f"Extracting: {config.LOGOS9_WINE64_BOTTLE_TARGZ_NAME}\ninto: {config.APPDIR}")
     shutil.unpack_archive(os.path.join(config.WORKDIR, config.LOGOS9_WINE64_BOTTLE_TARGZ_NAME), config.APPDIR)
 
+
 ## END WINE BOTTLE AND WINETRICKS FUNCTIONS
-## BEGIN LOGOS INSTALL FUNCTIONS 
+## BEGIN LOGOS INSTALL FUNCTIONS
 def get_logos_executable():
     PRESENT_WORKING_DIRECTORY = config.PRESENT_WORKING_DIRECTORY
     HOME = os.environ.get('HOME')
     # This VAR is used to verify the downloaded MSI is latest
     config.LOGOS_EXECUTABLE = f"{config.FLPRODUCT}_v{config.LOGOS_VERSION}-x64.msi"
-    
-    #cli_continue_question(f"Now the script will check for the MSI installer. Then it will download and install {FLPRODUCT} Bible at {WINEPREFIX}. You will need to interact with the installer. Do you wish to continue?", "The installation was cancelled!", "")
-    
+
+    # cli_continue_question(f"Now the script will check for the MSI installer. Then it will download and install {FLPRODUCT} Bible at {WINEPREFIX}. You will need to interact with the installer. Do you wish to continue?", "The installation was cancelled!", "")
+
     # Getting and installing {FLPRODUCT} Bible
     logging.info(f"Installing {config.FLPRODUCT}Bible 64bits…")
     utils.logos_reuse_download(config.LOGOS64_URL, config.LOGOS_EXECUTABLE, f"{config.APPDIR}/")
+
 
 def install_logos9(app):
     message = "Configuring wine bottle and installing app..."
@@ -308,8 +326,11 @@ def install_logos9(app):
     env = wine.get_wine_env()
 
     logging.info(f"======= Set {config.FLPRODUCT}Bible Indexing to Vista Mode: =======")
-    subprocess.run(f'{config.WINE_EXE} reg add "HKCU\\Software\\Wine\\AppDefaults\\{config.FLPRODUCT}Indexer.exe" /v Version /t REG_SZ /d vista /f', shell=True, env=env)
+    subprocess.run(
+        f'{config.WINE_EXE} reg add "HKCU\\Software\\Wine\\AppDefaults\\{config.FLPRODUCT}Indexer.exe" /v Version /t REG_SZ /d vista /f',
+        shell=True, env=env)
     logging.info(f"======= {config.FLPRODUCT}Bible logging set to Vista mode! =======")
+
 
 def install_logos10(app=None):
     message = "Configuring wine bottle and installing app..."
@@ -349,6 +370,7 @@ def install_logos10(app=None):
     get_logos_executable()
     wine.install_msi()
 
+
 def post_install(app):
     message = "Finishing installation..."
     msg.cli_msg(message)
@@ -367,7 +389,7 @@ def post_install(app):
         msg.cli_msg(message)
         logging.info(message)
 
-        if not os.path.isfile(config.CONFIG_FILE): # config.CONFIG_FILE is set in main() function
+        if not os.path.isfile(config.CONFIG_FILE):  # config.CONFIG_FILE is set in main() function
             logging.info(f"No config file at {config.CONFIG_FILE}")
             os.makedirs(os.path.join(HOME, ".config", "Logos_on_Linux"), exist_ok=True)
             if os.path.isdir(os.path.join(HOME, ".config", "Logos_on_Linux")):
@@ -385,7 +407,8 @@ def post_install(app):
                 if current_config_file_dict.get(key) != config.__dict__.get(key):
                     different = True
                     break
-            if different is True and msg.logos_acknowledge_question(f"Update config file at {config.CONFIG_FILE}?", "The existing config file was not overwritten."):
+            if different is True and msg.logos_acknowledge_question(f"Update config file at {config.CONFIG_FILE}?",
+                                                                    "The existing config file was not overwritten."):
                 logging.info(f"Updating config file.")
                 utils.write_config(config.CONFIG_FILE)
         else:
@@ -403,7 +426,7 @@ def post_install(app):
             shutil.copy(sys.executable, launcher_exe)
             create_shortcuts()
 
-        # NOTE: Can't launch installed app from installer if control panel is 
+        # NOTE: Can't launch installed app from installer if control panel is
         # running in a loop b/c of die_if_running function.
         #     if config.DIALOG == 'tk':
         #         subprocess.Popen(str(launcher_exe))
@@ -418,18 +441,22 @@ def post_install(app):
         msg.cli_msg(message)
         logging.info(message)
     else:
-        msg.logos_error(f"Installation failed. {config.LOGOS_EXE} not found. Exiting…\nThe {config.FLPRODUCT} executable was not found. This means something went wrong while installing {config.FLPRODUCT}. Please contact the Logos on Linux community for help.")
+        msg.logos_error(
+            f"Installation failed. {config.LOGOS_EXE} not found. Exiting…\nThe {config.FLPRODUCT} executable was not found. This means something went wrong while installing {config.FLPRODUCT}. Please contact the Logos on Linux community for help.")
+
 
 def install():
     prepare_install()
     finish_install()
 
+
 def prepare_install():
     choose_product()  # We ask user for his Faithlife product's name and set variables.
     choose_version()  # We ask user for his Faithlife product's version, set variables, and create project skeleton.
     get_logos_release_version()
-    logos_setup() # We set some basic variables for the install, including retrieving the product's latest release.
+    logos_setup()  # We set some basic variables for the install, including retrieving the product's latest release.
     choose_install_method()  # We ask user for his desired install method.
+
 
 def finish_install(app=None):
     message = "Beginning installation..."
@@ -448,12 +475,13 @@ def finish_install(app=None):
         install_logos9(app)  # We run the commands specific to Logos 9.
     else:
         msg.logos_error(f"TARGETVERSION unrecognized: '{config.TARGETVERSION}'. Installation canceled!")
-    
+
     wine.heavy_wineserver_wait()
     utils.clean_all()
 
     # Find and set LOGOS_EXE.    
-    exes = [e for e in glob.glob(f"{config.WINEPREFIX}/drive_c/**/{config.FLPRODUCT}.exe", recursive=True) if 'Pending' not in e]
+    exes = [e for e in glob.glob(f"{config.WINEPREFIX}/drive_c/**/{config.FLPRODUCT}.exe", recursive=True) if
+            'Pending' not in e]
     if len(exes) < 1:
         msg.logos_error("Logos was not installed.")
     config.LOGOS_EXE = exes[0]
@@ -462,6 +490,7 @@ def finish_install(app=None):
 
     if app is not None:
         app.root.event_generate("<<CheckInstallProgress>>")
+
 
 def create_desktop_file(name, contents):
     launcher_path = os.path.expanduser(f"~/.local/share/applications/{name}")

--- a/installer.py
+++ b/installer.py
@@ -507,7 +507,7 @@ def create_desktop_file(name, contents):
 def create_shortcuts():
     # Set icon variables.
     if config.LOGOS_ICON_URL is None:
-        config.LOGOS_ICON_URL = "https://raw.githubusercontent.com/ferion11/LogosLinuxInstaller/master/img/" + config.FLPRODUCTi + "-128-icon.png"
+        config.LOGOS_ICON_URL = "https://raw.githubusercontent.com/FaithLife-Community/LogosLinuxInstaller/master/img/" + config.FLPRODUCTi + "-128-icon.png"
     if config.LOGOS_ICON_FILENAME is None:
         config.LOGOS_ICON_FILENAME = os.path.basename(config.LOGOS_ICON_URL)
 

--- a/installer.py
+++ b/installer.py
@@ -46,6 +46,7 @@ def choose_product():
     if config.LOGOS_ICON_FILENAME is None:
         config.LOGOS_ICON_FILENAME = os.path.basename(config.LOGOS_ICON_URL)
 
+
 def get_logos_release_version():
     TITLE=f"Choose {config.FLPRODUCT} {config.TARGETVERSION} Release"
     QUESTION_TEXT=f"Which version of {config.FLPRODUCT} {config.TARGETVERSION} do you want to install?"
@@ -56,7 +57,9 @@ def get_logos_release_version():
         logos_release_version = config.LOGOS_VERSION
 
     logging.info(f"Release version: {logos_release_version}")
-    if logos_release_version is not None:
+    if logos_release_version == "Exit":
+        msg.logos_error("Exiting installation.", "")
+    elif logos_release_version is not None:
         config.LOGOS_RELEASE_VERSION = logos_release_version
     else:
         msg.logos_error("Failed to fetch LOGOS_RELEASE_VERSION.")
@@ -76,7 +79,7 @@ def choose_version():
     elif "9" in version_choice:
         config.TARGETVERSION = "9"
     elif version_choice == "Exit.":
-        sys.exit(0)
+        msg.logos_error("Exiting installation.", "")
     else:
         msg.logos_error("Unknown version. Installation canceled!", "")
     utils.check_dependencies()
@@ -118,12 +121,7 @@ def choose_install_method():
 
     if config.WINE_EXE is None:
         logging.info("Creating binary list.")
-        appimages = utils.find_appimage_files()
-        logging.debug(f"appimages: {', '.join(map(str, appimages))}")
-        binaries = utils.find_wine_binary_files()
-        logging.debug(f"binaries: {', '.join(map(str, binaries))}")
-        WINEBIN_OPTIONS = utils.get_wine_options(appimages, binaries)
-        print(WINEBIN_OPTIONS)
+        WINEBIN_OPTIONS = utils.get_wine_options(utils.find_appimage_files(), utils.find_wine_binary_files())
 
         BACKTITLE="Choose Wine Binary Menu"
         TITLE="Choose Wine Binary"
@@ -134,6 +132,8 @@ def choose_install_method():
         config.WINE_EXE = installationChoice[1]
         if config.WINEBIN_CODE == "Recommended" or config.WINEBIN_CODE == "AppImage":
             config.SELECTED_APPIMAGE_FILENAME = installationChoice[1]
+        elif config.WINEBIN_CODE == "Exit":
+            msg.logos_error("Exiting installation.", "")
 
         logging.info(f"WINEBIN_CODE: {config.WINEBIN_CODE}; WINE_EXE: {config.WINE_EXE}")
     variables = {

--- a/msg.py
+++ b/msg.py
@@ -81,7 +81,7 @@ def logos_warn(message):
         cli_msg(message)
 
 def logos_error(message, secondary=None):
-    WIKI_LINK = "https://github.com/ferion11/LogosLinuxInstaller/wiki"
+    WIKI_LINK = "https://github.com/FaithLife-Community/LogosLinuxInstaller/wiki"
     TELEGRAM_LINK = "https://t.me/linux_logos"
     MATRIX_LINK = "https://matrix.to/#/#logosbible:matrix.org"
     help_message = f"If you need help, please consult:\n{WIKI_LINK}\n{TELEGRAM_LINK}\n{MATRIX_LINK}"

--- a/tui.py
+++ b/tui.py
@@ -98,21 +98,30 @@ def menu(options, title, question_text):
             if index < len(options):
                 option = options[index]
                 if type(option) is list:
-                    # wine_binary_code = option[0]
-                    wine_binary_path = option[1]
-                    wine_binary_description = option[2]
                     option_lines = []
-                    wine_binary_path_wrapped = textwrap.wrap(
-                        f"Binary Path: {wine_binary_path}", window_width - 4)
-                    option_lines.extend(wine_binary_path_wrapped)
-                    wine_binary_desc_wrapped = textwrap.wrap(
-                        f"Description: {wine_binary_description}", window_width - 4)
-                    option_lines.extend(wine_binary_desc_wrapped)
+                    wine_binary_code = option[0]
+                    if wine_binary_code != "Exit":
+                        wine_binary_path = option[1]
+                        wine_binary_description = option[2]
+                        wine_binary_path_wrapped = textwrap.wrap(
+                            f"Binary Path: {wine_binary_path}", window_width - 4)
+                        option_lines.extend(wine_binary_path_wrapped)
+                        wine_binary_desc_wrapped = textwrap.wrap(
+                            f"Description: {wine_binary_description}", window_width - 4)
+                        option_lines.extend(wine_binary_desc_wrapped)
+                    else:
+                        wine_binary_path = option[1]
+                        wine_binary_description = option[2]
+                        wine_binary_path_wrapped = textwrap.wrap(
+                            f"{wine_binary_path}", window_width - 4)
+                        option_lines.extend(wine_binary_path_wrapped)
+                        wine_binary_desc_wrapped = textwrap.wrap(
+                            f"{wine_binary_description}", window_width - 4)
+                        option_lines.extend(wine_binary_desc_wrapped)
                 else:
                     option_lines = textwrap.wrap(option, window_width - 4)
 
                 for j, line in enumerate(option_lines):
-                    logging.info("Test 11")
                     y = options_start_y + i + j
                     x = max(0, window_width // 2 - len(line) // 2)
                     if y < window_height:

--- a/tui_app.py
+++ b/tui_app.py
@@ -33,11 +33,19 @@ def control_panel_app():
         options_default = ["Install Logos Bible Software"]
         options_exit = ["Exit"]
         if utils.file_exists(config.LOGOS_EXE):
-            options_installed = [f"Run {config.FLPRODUCT}", "Run Indexing", "Remove Library Catalog", "Remove All Index Files", "Edit Config", "Install Dependencies", "Back up Data", "Restore Data", "Set AppImage", "Download or Update Winetricks", "Run Winetricks"]
+            options_installed = [f"Run {config.FLPRODUCT}", "Run Indexing", "Remove Library Catalog", "Remove All Index Files", "Edit Config", "Install Dependencies", "Back up Data", "Restore Data"]
+            
+            if config.WINEBIN_CODE == "AppImage":
+                options_installed.append("Set AppImage")
+            
+            options_installed.append("Download or Update Winetricks")
+            options_installed.append("Run Winetricks")
+            
             if config.LOGS == "DISABLED":
                 options_installed.append("Enable Logging")
             else:
                 options_installed.append("Disable Logging")
+            
             options = options_default + options_installed + options_exit
         else:
             options = options_default + options_exit

--- a/utils.py
+++ b/utils.py
@@ -1100,6 +1100,9 @@ def find_appimage_files():
     if config.CUSTOMBINPATH is not None:
         directories.append(config.CUSTOMBINPATH)
 
+    if sys.version_info < (3, 12):
+        raise RuntimeError("Python 3.12 or higher is required for .rglob() flag `case-sensitive` ")
+
     for d in directories:
         appimage_paths = Path(d).rglob('wine*.appimage', case_sensitive=False)
         for p in appimage_paths:

--- a/utils.py
+++ b/utils.py
@@ -699,11 +699,14 @@ def get_logos_releases(q=None, app=None):
         # if len(releases) == 5:
         #    break
 
-    if q is not None and app is not None:
-        q.put(releases)
-        app.root.event_generate("<<ReleaseCheckProgress>>")
+    filtered_releases = filter_versions(releases, 30, 1)
     logging.debug(f"Available releases: {', '.join(releases)}")
-    return releases
+    logging.debug(f"Filtered releases: {', '.join(filtered_releases)}")
+
+    if q is not None and app is not None:
+        q.put(filtered_releases)
+        app.root.event_generate("<<ReleaseCheckProgress>>")
+    return filtered_releases
 
 
 def get_winebin_code_and_desc(binary):


### PR DESCRIPTION
This is a partial fix for #5. It adds conditional logic to the CLI, TUI, and GUI that either removes or disables a function if the config file states that the Logos install was created with something other than an AppImage.

It also creates a new GUI tooltip function. This is applied to the set appimage button, so that when the user hovers over it with his mouse, it will tell him why the button is disabled.