### PR TITLE
Allow `--install-dependencies` to run on a clean install

### DIFF
--- a/LogosLinuxInstaller.py
+++ b/LogosLinuxInstaller.py
@@ -303,7 +303,7 @@ def main():
     utils.self_update()
 
     # Check if app is installed.
-    install_not_required = [ 'remove_install_dir', 'utils.check_dependencies', 'update_to_latest_recommended_appimage', 'set_appimage_symlink' ]
+    install_not_required = [ 'remove_install_dir', 'check_dependencies', 'update_to_latest_recommended_appimage', 'set_appimage_symlink' ]
     if config.ACTION == "disabled":
         msg.logos_error("That option is disabled.", "info")
     elif config.ACTION.__name__ in install_not_required:  # These actions don't require an install

--- a/utils.py
+++ b/utils.py
@@ -645,8 +645,11 @@ def check_libs(libraries):
 
 
 def check_dependencies():
-    targetversion = int(config.TARGETVERSION)
-    logging.info(f"Checking Logos {str(targetversion)} dependencies")
+    if config.TARGETVERSION:
+        targetversion = int(config.TARGETVERSION)
+    else:
+        targetversion = 10
+    logging.info(f"Checking Logos {str(targetversion)} dependencies…")
     if targetversion == 10:
         install_dependencies(config.PACKAGES, config.BADPACKAGES)
     elif targetversion == 9:


### PR DESCRIPTION
This subcommand wasn't working correctly, and it required that `TARGETVERSION` be set. These changes allow any user or potential user to simply run `LogosLinuxInstaller --install-dependencies [-D]` and report back any errors, without having to try to install Logos or Wine.
- fix typo in `LogosLinuxInstaller.py`
- default to `TARGETVERSION = 10` if not set by user