### PR TITLE
Update Debian and Ubuntu Deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ NOTE: The following section is WIP.
 ### Install Dependencies
 
 ```
-sudo apt install mktemp patch lsof wget find sed grep gawk tr winbind cabextract x11-apps bc 
+sudo apt install coreutils patch lsof wget findutils sed grep gawk winbind cabextract x11-apps bc binutils
 ```
 
 If using wine from a repo, you must install wine staging. Run:

--- a/utils.py
+++ b/utils.py
@@ -367,7 +367,7 @@ def get_package_manager():
         # IDEA: Switch to Python APT library?
         # See https://github.com/FaithLife-Community/LogosLinuxInstaller/pull/33#discussion_r1443623996  # noqa: E501
         config.PACKAGE_MANAGER_COMMAND_QUERY = "dpkg -l | grep -E '^.i  '"
-        config.PACKAGES = "binutils cabextract fuse wget winbind"
+        config.PACKAGES = "coreutils patch lsof wget findutils sed grep gawk winbind cabextract x11-apps bc binutils fuse3"
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
         config.BADPACKAGES = "appimagelauncher"
     elif shutil.which('dnf') is not None:  # rhel, fedora


### PR DESCRIPTION
This fixes two minor issues I found while trying to install on Ubuntu 22.04. Note that `ensure-python.sh` doesn't work on Ubuntu 22.04 yet, since winehq-staging is not found in the repo added to apt. But I think these two bugfixes are still worth merging.