### PR TITLE
Update Manjaro Deps

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -394,7 +394,7 @@ def get_package_manager():
         config.PACKAGE_MANAGER_COMMAND_INSTALL = "pamac install --no-upgrade --no-confirm"  # noqa: E501
         config.PACKAGE_MANAGER_COMMAND_REMOVE = "pamac remove --no-confirm"
         config.PACKAGE_MANAGER_COMMAND_QUERY = "pamac list -i | grep -E ^"
-        config.PACKAGES = "patch wget sed grep gawk cabextract samba bc libxml2 curl"  # noqa: E501
+        config.PACKAGES = "wget sed grep gawk cabextract samba"  # noqa: E501
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
         config.BADPACKAGES = "appimagelauncher"
     elif shutil.which('pacman') is not None:  # arch, steamOS


### PR DESCRIPTION
This continues work on #1. This update seeks to fix Manjaro deps by removing deps from the original Bash source.

- bc, libxml2 are no longer needed due to Python
- cabextract is for Logos 9
- patch I believe was also Logos 9, but I don't know what for

This needs verification but we should be able to remove sed and grep unless winetricks needs them, per #90.

We may also need to add `patch` to Logos 9 requirements, but I don't think so?

Perhaps curl can be removed? Perhaps also wget?