### PR TITLE
Fix Install Issues

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -701,7 +701,9 @@ class ControlWindow():
         t.start()
 
     def install_deps(self, evt=None):
-        utils.check_dependencies()
+        t = Thread(target=utils.check_dependencies, daemon=True)
+        self.start_indeterminate_progress()
+        t.start()
 
     def open_file_dialog(self, filetype_name, filetype_extension):
         file_path = fd.askopenfilename(

--- a/installer.py
+++ b/installer.py
@@ -314,7 +314,6 @@ def ensure_sys_deps(app=None):
     update_install_feedback("Ensuring system dependencies are met…", app=app)
 
     if not config.SKIP_DEPENDENCIES:
-        utils.get_package_manager()
         utils.check_dependencies()
         logging.debug("> Done.")
     else:

--- a/tui_app.py
+++ b/tui_app.py
@@ -96,6 +96,8 @@ def control_panel_app():
 
         if choice is None or choice == "Exit":
             sys.exit(0)
+        elif choice == "Install Dependencies":
+            utils.check_dependencies()
         elif choice.startswith("Install"):
             installer.ensure_launcher_shortcuts()
         elif choice.startswith("Update Logos Linux Installer"):
@@ -110,8 +112,6 @@ def control_panel_app():
             control.remove_all_index_files()
         elif choice == "Edit Config":
             control.edit_config()
-        elif choice == "Install Dependencies":
-            utils.check_dependencies()
         elif choice == "Back up Data":
             control.backup()
         elif choice == "Restore Data":

--- a/utils.py
+++ b/utils.py
@@ -133,6 +133,7 @@ class UrlProps(Props):
 # Set "global" variables.
 def set_default_config():
     get_os()
+    get_superuser_command()
     get_package_manager()
     if config.CONFIG_FILE is None:
         config.CONFIG_FILE = config.DEFAULT_CONFIG_PATH
@@ -355,13 +356,23 @@ def get_os():
     return config.OS_NAME, config.OS_RELEASE
 
 
-def get_package_manager():
-    # Check for superuser command
-    if shutil.which('sudo') is not None:
-        config.SUPERUSER_COMMAND = "sudo"
-    elif shutil.which('doas') is not None:
-        config.SUPERUSER_COMMAND = "doas"
+def get_superuser_command():
+    if config.DIALOG == 'tk':
+        if shutil.which('pkexec'):
+            config.SUPERUSER_COMMAND = "pkexec"
+        else:
+            logging.critical("No superuser command found. Please install pkexec.")
+    elif config.DIALOG != 'tk':
+        if shutil.which('sudo'):
+            config.SUPERUSER_COMMAND = "sudo"
+        elif shutil.which('doas'):
+            config.SUPERUSER_COMMAND = "doas")
+        else:
+            logging.critical("No superuser command found. Please install sudo or doas.")
+    logging.debug(f"{config.SUPERUSER_COMMAND=}")
 
+
+def get_package_manager():
     # Check for package manager and associated packages
     if shutil.which('apt') is not None:  # debian, ubuntu
         config.PACKAGE_MANAGER_COMMAND_INSTALL = "apt install -y"
@@ -396,7 +407,6 @@ def get_package_manager():
     # Add more conditions for other package managers as needed
 
     # Add logging output.
-    logging.debug(f"{config.SUPERUSER_COMMAND=}")
     logging.debug(f"{config.PACKAGE_MANAGER_COMMAND_INSTALL=}")
     logging.debug(f"{config.PACKAGE_MANAGER_COMMAND_QUERY=}")
     logging.debug(f"{config.PACKAGES=}")

--- a/utils.py
+++ b/utils.py
@@ -758,12 +758,16 @@ def check_libs(libraries):
                     f"The script could not determine your {config.OS_NAME} install's package manager or it is unsupported. Your computer is missing the library: {library}. Please install the package associated with {library} for {config.OS_NAME}.")  # noqa: E501
 
 
-def check_dependencies():
+def check_dependencies(app=None):
     if config.TARGETVERSION:
         targetversion = int(config.TARGETVERSION)
     else:
         targetversion = 10
     logging.info(f"Checking Logos {str(targetversion)} dependencies…")
+    if app:
+        app.status_q.put(f"Checking Logos {str(targetversion)} dependencies…")
+        app.root.event_generate('<<UpdateStatus>>')
+
     if targetversion == 10:
         install_dependencies(config.PACKAGES, config.BADPACKAGES)
     elif targetversion == 9:
@@ -774,6 +778,9 @@ def check_dependencies():
         )
     else:
         logging.error(f"TARGETVERSION not found: {config.TARGETVERSION}.")
+
+    if app:
+        app.root.event_generate('<<StopIndeterminateProgress>>')
 
 
 def file_exists(file_path):

--- a/utils.py
+++ b/utils.py
@@ -361,14 +361,14 @@ def get_superuser_command():
         if shutil.which('pkexec'):
             config.SUPERUSER_COMMAND = "pkexec"
         else:
-            logging.critical("No superuser command found. Please install pkexec.")
-    elif config.DIALOG != 'tk':
+            msg.logos_error("No superuser command found. Please install pkexec.")  # noqa: E501
+    else:
         if shutil.which('sudo'):
             config.SUPERUSER_COMMAND = "sudo"
         elif shutil.which('doas'):
-            config.SUPERUSER_COMMAND = "doas")
+            config.SUPERUSER_COMMAND = "doas"
         else:
-            logging.critical("No superuser command found. Please install sudo or doas.")
+            msg.logos_error("No superuser command found. Please install sudo or doas.")  # noqa: E501
     logging.debug(f"{config.SUPERUSER_COMMAND=}")
 
 


### PR DESCRIPTION
If an Ubuntu user is running the GUI and needs dependencies installed, the installer will hang because it's waiting fruitlessly for a `sudo` password. The user would only maybe notice this if they start the installer from the terminal, which not a typical use-case for the GUI. Otherwise the prompt is unreachable. This change prioritizes `pkexec` over `sudo`, because `pkexec` will pop up a graphical password prompt. I think this will also give a graphical prompt for a user running the TUI, if there's an available display, otherwise it will fallback to a terminal prompt.

The 2nd change is making sure the TUI checks for "Install dependencies" before checking for a choice that starts with "Install". The original order meant that if the user selected "Install dependencies" from the menu, it actually ran the full installer, since the choice started with "Install".

Both of these changes have been tested on a new Ubuntu 24.04 installation.