### PR TITLE
Add Architecture Detection

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -67,6 +67,9 @@ DEFAULT_CONFIG_PATH = os.path.expanduser(f"~/.config/FaithLife-Community/{name_b
 FLPRODUCTi: Optional[str] = None
 INSTALL_STEP: int = 0
 INSTALL_STEPS_COUNT: int = 0
+architecture = None
+bits = None
+ELFPACKAGES = None
 L9PACKAGES = None
 LEGACY_CONFIG_FILES = [
     os.path.expanduser("~/.config/FaithLife-Community/Logos_on_Linux.json"),  # noqa: E501

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -380,6 +380,11 @@ def set_dialog():
             logging.error("Dialog version is outdated. The program will fall back to Curses.")  # noqa: E501
             config.use_python_dialog = False
     logging.debug(f"Use Python Dialog?: {config.use_python_dialog}")
+    # Set Architecture
+
+    config.architecture, config.bits = system.get_architecture()
+    logging.debug(f"Current Architecture: {config.architecture}, {config.bits}bit.")
+    system.check_architecture()
 
 
 def check_incompatibilities():

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -3,7 +3,9 @@ import distro
 import logging
 import os
 import psutil
+import platform
 import shutil
+import struct
 import subprocess
 import sys
 import time
@@ -14,6 +16,7 @@ from pathlib import Path
 from . import config
 from . import msg
 from . import network
+from . import utils
 
 
 # TODO: Replace functions in control.py and wine.py with Popen command.
@@ -232,6 +235,67 @@ def get_dialog():
         config.DIALOG = 'tk'
 
 
+def get_architecture():
+    machine = platform.machine().lower()
+    bits = struct.calcsize("P") * 8
+
+    if "x86_64" in machine or "amd64" in machine:
+        architecture = "x86_64"
+    elif "i386" in machine or "i686" in machine:
+        architecture = "x86_32"
+    elif "arm" in machine or "aarch64" in machine:
+        if bits == 64:
+            architecture = "ARM64"
+        else:
+            architecture = "ARM32"
+    elif "riscv" in machine or "riscv64" in machine:
+        if bits == 64:
+            architecture = "RISC-V 64"
+        else:
+            architecture = "RISC-V 32"
+    else:
+        architecture = "Unknown"
+
+    return architecture, bits
+
+
+def install_elf_interpreter():
+    # TODO: This probably needs to be changed to another install step that requests the user to choose a specific
+    # ELF interpreter between box64, FEX-EMU, and hangover. That or else we have to pursue a particular interpreter
+    # for the install routine, depending on what's needed
+    logging.critical("ELF interpretation is not yet coded in the installer.")
+    # if "x86_64" not in config.architecture:
+    #     if config.ELFPACKAGES is not None:
+    #         utils.install_packages(config.ELFPACKAGES)
+    #     else:
+    #         logging.critical(f"ELFPACKAGES is not set.")
+    #         sys.exit(1)
+    # else:
+    #     logging.critical(f"ELF interpreter is not needed.")
+
+
+def check_architecture():
+    if "x86_64" in config.architecture:
+        pass
+    elif "ARM64" in config.architecture:
+        logging.critical("Unsupported architecture. Requires box64 or FEX-EMU or Wine Hangover to be integrated.")
+        install_elf_interpreter()
+    elif "RISC-V 64" in config.architecture:
+        logging.critical("Unsupported architecture. Requires box64 or FEX-EMU or Wine Hangover to be integrated.")
+        install_elf_interpreter()
+    elif "x86_32" in config.architecture:
+        logging.critical("Unsupported architecture. Requires box64 or FEX-EMU or Wine Hangover to be integrated.")
+        install_elf_interpreter()
+    elif "ARM32" in config.architecture:
+        logging.critical("Unsupported architecture. Requires box64 or FEX-EMU or Wine Hangover to be integrated.")
+        install_elf_interpreter()
+    elif "RISC-V 32" in config.architecture:
+        logging.critical("Unsupported architecture. Requires box64 or FEX-EMU or Wine Hangover to be integrated.")
+        install_elf_interpreter()
+    else:
+        logging.critical("System archictecture unknown.")
+
+
 def get_os():
     # FIXME: Not working? Returns "Linux" on some systems? On Ubuntu 24.04 it
     # correctly returns "ubuntu".
@@ -298,6 +362,7 @@ def get_package_manager():
                 "7zip "  # winetricks
             )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
+        config.ELFPACKAGES = ""
         config.BADPACKAGES = ""  # appimagelauncher handled separately
     elif shutil.which('dnf') is not None:  # rhel, fedora
         config.PACKAGE_MANAGER_COMMAND_INSTALL = ["dnf", "install", "-y"]
@@ -319,6 +384,7 @@ def get_package_manager():
             "p7zip-plugins "  # winetricks
         )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
+        config.ELFPACKAGES = ""
         config.BADPACKAGES = ""  # appimagelauncher handled separately
     elif shutil.which('zypper') is not None:  # manjaro
         config.PACKAGE_MANAGER_COMMAND_INSTALL = ["zypper", "--non-interactive", "install"]  # noqa: E501
@@ -347,6 +413,7 @@ def get_package_manager():
             "curl gawk grep "  # other
         )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
+        config.ELFPACKAGES = ""
         config.BADPACKAGES = ""  # appimagelauncher handled separately
     elif shutil.which('pacman') is not None:  # arch, steamOS
         config.PACKAGE_MANAGER_COMMAND_INSTALL = ["pacman", "-Syu", "--overwrite", "\\*", "--noconfirm", "--needed"]  # noqa: E501
@@ -369,6 +436,7 @@ def get_package_manager():
                 "libxslt sqlite "  # misc
             )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
+        config.ELFPACKAGES = ""
         config.BADPACKAGES = ""  # appimagelauncher handled separately
     else:
         # Add more conditions for other package managers as needed.


### PR DESCRIPTION
This PR is a WIP draft working to implement ELF interpreter support from [box64](https://github.com/ptitSeb/box64) and/or [FEX-EMU](https://github.com/FEX-Emu/FEX) and/or [Wine Hangover](https://github.com/AndreRH/hangover) in order to be able to install current Logos 64bit versions on Linux 32 bit, ARM 32 bit, ARM 64 bit, RISC-V 32 bit and RISC-V 64-bit.

The current code errors during install and exits the program if the architecture is not x86_64.

Technically the ELF interpreters could let us install modern Logos 10 on x86 machines (not x86_64).

cf. #24 

The initial PR is to get the basics in place for us to play with.

---

UPDATE: 20241126

As of the most recent commits to box64 (~9/20), ou dedetai built with pyinstaller now loads.

A test of Wine Hangover 9.20 suggests that it is in fact loading, but I hit possibly #107 and also the Panfrost Driver being under-developed.

Next steps are testing another non-panfrost ARM SoC to see if the login window loads.

In terms of development, the next step is to pick at least one method, i.e., box64, fex, hangover, and place the packages in the ELFPACKAGES var, and then ensure at least one of them is installed—or—we assume box64 is installed and we set up the program to install hangover, which may not be available in repos. I personally prefer box64 for its simplicity.