### PR TITLE
Fix #121, #124. Prep for #118.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
+- 4.0.0-alpha.10
+	- Fix #121 [T. H. Wright]
+	- Prep for Logos 30+ support [N. Marti, T. H. Wright]
 - 4.0.0-alpha.9
 	- Fix #42 [T. H. Wright]
-	- Fix #76, #104 [T. H. Wright]
+	- Fix #76, #104, #111, #115 [T. H. Wright]
 - 4.0.0-alpha.8
 	- Fix #1 [T. H. Wright, N. Marti, T. Bleher, C. Reeder]
 	- Fix #102 [T. H. Wright]

--- a/config.py
+++ b/config.py
@@ -6,11 +6,8 @@ import tempfile
 
 # Define and set variables that are required in the config file.
 core_config_keys = [
-<<<<<<< HEAD
-    "FLPRODUCT", "FLPRODUCTi", "TARGETVERSION", "LOGOS_RELEASE_VERSION",
-=======
-    "current_logos_version", "FLPRODUCT", "TARGETVERSION", "LOGOS_RELEASE_VERSION",
->>>>>>> 1a0c240 (Add utils.get_logos_version())
+    "FLPRODUCT", "FLPRODUCTi", "TARGETVERSION", "TARGET_RELEASE_VERSION",
+    "current_logos_version", "FLPRODUCT", "TARGETVERSION",
     "INSTALLDIR", "WINETRICKSBIN", "WINEBIN_CODE", "WINE_EXE",
     "WINECMD_ENCODING", "LOGS", "BACKUPDIR", "LAST_UPDATED",
     "RECOMMENDED_WINE64_APPIMAGE_URL", "LLI_LATEST_VERSION"

--- a/config.py
+++ b/config.py
@@ -6,7 +6,11 @@ import tempfile
 
 # Define and set variables that are required in the config file.
 core_config_keys = [
+<<<<<<< HEAD
     "FLPRODUCT", "FLPRODUCTi", "TARGETVERSION", "LOGOS_RELEASE_VERSION",
+=======
+    "current_logos_version", "FLPRODUCT", "TARGETVERSION", "LOGOS_RELEASE_VERSION",
+>>>>>>> 1a0c240 (Add utils.get_logos_version())
     "INSTALLDIR", "WINETRICKSBIN", "WINEBIN_CODE", "WINE_EXE",
     "WINECMD_ENCODING", "LOGS", "BACKUPDIR", "LAST_UPDATED",
     "RECOMMENDED_WINE64_APPIMAGE_URL", "LLI_LATEST_VERSION"
@@ -58,7 +62,7 @@ INSTALL_STEPS_COUNT = 0
 L9PACKAGES = None
 LEGACY_CONFIG_FILE = os.path.expanduser("~/.config/Logos_on_Linux/Logos_on_Linux.conf")  # noqa: E501
 LLI_AUTHOR = "Ferion11, John Goodman, T. H. Wright, N. Marti"
-LLI_CURRENT_VERSION = "4.0.0-alpha.9"
+LLI_CURRENT_VERSION = "4.0.0-alpha.10"
 LLI_LATEST_VERSION = None
 LLI_TITLE = "Logos Linux Installer"
 LOG_LEVEL = logging.WARNING

--- a/gui.py
+++ b/gui.py
@@ -26,7 +26,7 @@ class InstallerGui(Frame):
         # Initialize vars from ENV.
         self.flproduct = config.FLPRODUCT
         self.targetversion = config.TARGETVERSION
-        self.logos_release_version = config.LOGOS_RELEASE_VERSION
+        self.logos_release_version = config.TARGET_RELEASE_VERSION
         self.default_config_path = config.DEFAULT_CONFIG_PATH
         self.wine_exe = config.WINE_EXE
         self.winetricksbin = config.WINETRICKSBIN
@@ -153,7 +153,7 @@ class ControlGui(Frame):
         self.installdir = config.INSTALLDIR
         self.flproduct = config.FLPRODUCT
         self.targetversion = config.TARGETVERSION
-        self.logos_release_version = config.LOGOS_RELEASE_VERSION
+        self.logos_release_version = config.TARGET_RELEASE_VERSION
         self.logs = config.LOGS
         self.config_file = config.CONFIG_FILE
 

--- a/installer.py
+++ b/installer.py
@@ -48,6 +48,7 @@ def ensure_version_choice(app=None):
             if config.DIALOG == 'curses':
                 app.version_e.wait()
             config.TARGETVERSION = app.version_q.get()
+
     logging.debug(f"> {config.TARGETVERSION=}")
 
 
@@ -56,16 +57,17 @@ def ensure_release_choice(app=None):
     ensure_version_choice(app=app)
     config.INSTALL_STEP += 1
     update_install_feedback("Choose product release…", app=app)
-    logging.debug('- config.LOGOS_RELEASE_VERSION')
+    logging.debug('- config.TARGET_RELEASE_VERSION')
 
-    if not config.LOGOS_RELEASE_VERSION:
+    if not config.TARGET_RELEASE_VERSION:
         if app:
-            utils.send_task(app, 'LOGOS_RELEASE_VERSION')
+            utils.send_task(app, 'TARGET_RELEASE_VERSION')
             if config.DIALOG == 'curses':
                 app.release_e.wait()
-            config.LOGOS_RELEASE_VERSION = app.release_q.get()
-            logging.debug(f"{config.LOGOS_RELEASE_VERSION=}")
-    logging.debug(f"> {config.LOGOS_RELEASE_VERSION=}")
+            config.TARGET_RELEASE_VERSION = app.release_q.get()
+            logging.debug(f"{config.TARGET_RELEASE_VERSION=}")
+
+    logging.debug(f"> {config.TARGET_RELEASE_VERSION=}")
 
 
 def ensure_install_dir_choice(app=None):
@@ -189,9 +191,9 @@ def ensure_installation_config(app=None):
     logos_icon_url = app_dir / 'img' / f"{config.FLPRODUCTi}-128-icon.png"
     config.LOGOS_ICON_URL = str(logos_icon_url)
     config.LOGOS_ICON_FILENAME = logos_icon_url.name
-    config.LOGOS64_URL = f"https://downloads.logoscdn.com/LBS{config.TARGETVERSION}{config.VERBUM_PATH}Installer/{config.LOGOS_RELEASE_VERSION}/{config.FLPRODUCT}-x64.msi"  # noqa: E501
+    config.LOGOS64_URL = f"https://downloads.logoscdn.com/LBS{config.TARGETVERSION}{config.VERBUM_PATH}Installer/{config.TARGET_RELEASE_VERSION}/{config.FLPRODUCT}-x64.msi"  # noqa: E501
 
-    config.LOGOS_VERSION = config.LOGOS_RELEASE_VERSION
+    config.LOGOS_VERSION = config.TARGET_RELEASE_VERSION
     config.LOGOS64_MSI = Path(config.LOGOS64_URL).name
 
     logging.debug(f"> {config.LOGOS_ICON_URL=}")

--- a/main.py
+++ b/main.py
@@ -316,12 +316,13 @@ def main():
         config.use_python_dialog = utils.test_dialog_version()
 
         if config.use_python_dialog is None:
-            logging.debug("The 'dialog' package was not found.")
+            logging.debug("The 'dialog' package was not found. Please install it or use the GUI.")
+            config.use_python_dialog = False # In order to prevent errors, make sure now to set dialog to False.
         elif config.use_python_dialog:
             logging.debug("Dialog version is up-to-date.")
             config.use_python_dialog = True
         else:
-            logging.error("Dialog version is outdated. Please use the GUI.")
+            logging.error("Dialog version is outdated. The program will fall back to Curses.")
             config.use_python_dialog = False
 
     # Log persistent config.

--- a/tui_curses.py
+++ b/tui_curses.py
@@ -15,13 +15,17 @@ def wrap_text(app, text):
     return lines
 
 
-def title(app, title_text):
+def title(app, title_text, title_start_y_adj):
     stdscr = app.get_main_window()
     title_lines = wrap_text(app, title_text)
     title_start_y = max(0, app.window_height // 2 - len(title_lines) // 2)
+    last_index = 0
     for i, line in enumerate(title_lines):
         if i < app.window_height:
-            stdscr.addstr(i, 2, line, curses.A_BOLD)
+            stdscr.addstr(i + title_start_y_adj, 2, line, curses.A_BOLD)
+        last_index = i
+
+    return last_index
 
 
 def text_centered(app, text, start_y=0):

--- a/tui_screen.py
+++ b/tui_screen.py
@@ -63,16 +63,19 @@ class DialogScreen(Screen):
 
 
 class ConsoleScreen(CursesScreen):
-    def __init__(self, app, screen_id, queue, event, title):
+    def __init__(self, app, screen_id, queue, event, title, subtitle, title_start_y):
         super().__init__(app, screen_id, queue, event)
         self.stdscr = self.app.get_main_window()
         self.title = title
+        self.subtitle = subtitle
+        self.title_start_y = title_start_y
 
     def display(self):
         self.stdscr.erase()
-        tui_curses.title(self.app, self.title)
+        subtitle_start = tui_curses.title(self.app, self.title, self.title_start_y)
+        tui_curses.title(self.app, self.subtitle, subtitle_start + 1)
 
-        self.stdscr.addstr(2, 2, f"---Console---")
+        self.stdscr.addstr(3, 2, f"---Console---")
         recent_messages = logging.console_log[-6:]
         for i, message in enumerate(recent_messages, 1):
             message_lines = tui_curses.wrap_text(self.app, message)

--- a/utils.py
+++ b/utils.py
@@ -987,7 +987,7 @@ def file_exists(file_path):
         return False
 
 
-def get_logos_version():
+def get_current_logos_version():
     path_regex = f"{config.INSTALLDIR}/data/wine64_bottle/drive_c/users/*/AppData/Local/Logos/System/Logos.deps.json"
     file_paths = glob.glob(path_regex)
     if file_paths:
@@ -1005,6 +1005,22 @@ def get_logos_version():
             return None
     else:
         logging.debug(f"Logos.deps.json not found.")
+
+
+def convert_logos_release(logos_release):
+    if logos_release is not None:
+        ver_major = logos_release.split('.')[0]
+        ver_minor = logos_release.split('.')[1]
+        release = logos_release.split('.')[2]
+        point = logos_release.split('.')[3]
+    else:
+        ver_major = 0
+        ver_minor = 0
+        release = 0
+        point = 0
+
+    logos_release_arr = [int(ver_major), int(ver_minor), int(release), int(point)]
+    return logos_release_arr
 
 
 def check_logos_release_version(version, threshold, check_version_part):
@@ -1537,7 +1553,7 @@ def check_for_updates():
     # order to avoid GitHub API limits. This sets the check to once every 12
     # hours.
 
-    config.current_logos_version = get_logos_version()
+    config.current_logos_version = get_current_logos_version()
     write_config(config.CONFIG_FILE)
 
     # TODO: Check for New Logos Versions. See #116.

--- a/utils.py
+++ b/utils.py
@@ -527,7 +527,7 @@ def query_packages(packages, elements=None, mode="install", app=None):
                     f"Checking Packages {(packages.index(p) + 1)}/{len(packages)}",
                     100 * (packages.index(p) + 1) // len(packages),
                     elements,
-                    dialog=True)
+                    dialog=config.use_python_dialog)
 
     msg = 'None'
     if mode == "install":
@@ -560,7 +560,7 @@ def download_packages(packages, elements, app=None):
 
             if app is not None and config.DIALOG == "curses" and elements is not None:
                 app.report_dependencies(f"Downloading Packages ({index + 1}/{total_packages})",
-                                        100 * (index + 1) // total_packages, elements, dialog=True)
+                                        100 * (index + 1) // total_packages, elements, dialog=config.use_python_dialog)
 
 
 def install_packages(packages, elements, app=None):
@@ -584,7 +584,7 @@ def install_packages(packages, elements, app=None):
                     f"Installing Packages ({index + 1}/{total_packages})",
                     100 * (index + 1) // total_packages,
                     elements,
-                    dialog=True)
+                    dialog=config.use_python_dialog)
 
 
 def remove_packages(packages, elements, app=None):
@@ -608,7 +608,7 @@ def remove_packages(packages, elements, app=None):
                     f"Removing Packages ({index + 1}/{total_packages})",
                     100 * (index + 1) // total_packages,
                     elements,
-                    dialog=True)
+                    dialog=config.use_python_dialog)
 
 
 def have_dep(cmd):
@@ -877,7 +877,7 @@ def install_dependencies(packages, badpackages, logos9_packages=None, app=None):
             bad_elements[p] = "Unchecked"
 
     if config.DIALOG == "curses" and app is not None:
-        app.report_dependencies("Checking Packages", 0, elements, dialog=True)
+        app.report_dependencies("Checking Packages", 0, elements, dialog=config.use_python_dialog)
 
     if config.PACKAGE_MANAGER_COMMAND_QUERY:
         missing_packages, elements = query_packages(package_list, elements, app=app)

--- a/utils.py
+++ b/utils.py
@@ -417,8 +417,6 @@ def get_package_manager():
         config.PACKAGE_MANAGER_COMMAND_INSTALL = "apt install -y"
         config.PACKAGE_MANAGER_COMMAND_DOWNLOAD = "apt install --download-only -y"
         config.PACKAGE_MANAGER_COMMAND_REMOVE = "apt remove -y"
-        # IDEA: Switch to Python APT library?
-        # See https://github.com/FaithLife-Community/LogosLinuxInstaller/pull/33#discussion_r1443623996  # noqa: E501
         config.PACKAGE_MANAGER_COMMAND_QUERY = "dpkg -l"
         config.QUERY_PREFIX = '.i  '
         if distro.id() == "ubuntu" and distro.version() < "24.04":
@@ -791,16 +789,16 @@ def delete_symlink(symlink_path):
 
 def preinstall_dependencies_ubuntu():
     try:
-        run_command(["sudo", "dpkg", "--add-architecture", "i386"])
-        run_command(["sudo", "mkdir", "-pm755", "/etc/apt/keyrings"])
+        run_command([config.SUPERUSER_COMMAND, "dpkg", "--add-architecture", "i386"])
+        run_command([config.SUPERUSER_COMMAND, "mkdir", "-pm755", "/etc/apt/keyrings"])
         run_command(
-            ["sudo", "wget", "-O", "/etc/apt/keyrings/winehq-archive.key", "https://dl.winehq.org/wine-builds/winehq.key"])
+            [config.SUPERUSER_COMMAND, "wget", "-O", "/etc/apt/keyrings/winehq-archive.key", "https://dl.winehq.org/wine-builds/winehq.key"])
         lsboutput = run_command(["lsb_release", "-a"])
         codename = [line for line in lsboutput.split('\n') if "Description" in line][0].split()[1].strip()
-        run_command(["sudo", "wget", "-NP", "/etc/apt/sources.list.d/",
+        run_command([config.SUPERUSER_COMMAND, "wget", "-NP", "/etc/apt/sources.list.d/",
                      f"https://dl.winehq.org/wine-builds/ubuntu/dists/{codename}/winehq-{codename}.sources"])
-        run_command(["sudo", "apt", "update"])
-        run_command(["sudo", "apt", "install", "--install-recommends", "winehq-staging"])
+        run_command([config.SUPERUSER_COMMAND, "apt", "update"])
+        run_command([config.SUPERUSER_COMMAND, "apt", "install", "--install-recommends", "winehq-staging"])
     except subprocess.CalledProcessError as e:
         print(f"An error occurred: {e}")
         print(f"Command output: {e.output}")

--- a/wine.py
+++ b/wine.py
@@ -107,11 +107,11 @@ def get_wine_release(binary):
         return False, f"Error: {e}"
 
 
-def check_wine_version_and_branch(TESTBINARY):
+def check_wine_version_and_branch(release_version, test_binary):
     # Does not check for Staging. Will not implement: expecting merging of
     # commits in time.
     if config.TARGETVERSION == "10":
-        if utils.check_logos_release_version(config.current_logos_version, 30, 1):
+        if utils.check_logos_release_version(release_version, 30, 1):
             WINE_MINIMUM = [7, 18]
         else:
             WINE_MINIMUM = [9, 10]
@@ -123,16 +123,16 @@ def check_wine_version_and_branch(TESTBINARY):
     # Check if the binary is executable. If so, check if TESTBINARY's version
     # is ≥ WINE_MINIMUM, or if it is Proton or a link to a Proton binary, else
     # remove.
-    if not os.path.exists(TESTBINARY):
+    if not os.path.exists(test_binary):
         reason = "Binary does not exist."
         return False, reason
 
-    if not os.access(TESTBINARY, os.X_OK):
+    if not os.access(test_binary, os.X_OK):
         reason = "Binary is not executable."
         return False, reason
 
     wine_release = []
-    wine_release, error_message = get_wine_release(TESTBINARY)
+    wine_release, error_message = get_wine_release(test_binary)
 
     if wine_release is not False and error_message is not None:
         if wine_release[2] == 'stable':
@@ -141,8 +141,8 @@ def check_wine_version_and_branch(TESTBINARY):
             return False, "Version is < 7.0"
         elif wine_release[0] == 7:
             if (
-                "Proton" in TESTBINARY
-                or ("Proton" in os.path.realpath(TESTBINARY) if os.path.islink(TESTBINARY) else False)  # noqa: E501
+                "Proton" in test_binary
+                or ("Proton" in os.path.realpath(test_binary) if os.path.islink(test_binary) else False)  # noqa: E501
             ):
                 if wine_release[1] == 0:
                     return True, "None"

--- a/wine.py
+++ b/wine.py
@@ -373,13 +373,22 @@ def get_wine_branch(binary):
             stdout=subprocess.PIPE,
             encoding='UTF8'
         )
+        branch = None
         while p.returncode is None:
             for line in p.stdout:
                 if line.startswith('/tmp'):
                     tmp_dir = Path(line.rstrip())
-                    for f in tmp_dir.glob('**/lib64/**/mscoree.dll'):
-                        branch = get_mscoree_winebranch(f)
-                        break
+                    for f in tmp_dir.glob('org.winehq.wine.desktop'):
+                        if not branch:
+                            for dline in f.read_text().splitlines():
+                                try:
+                                    k, v = dline.split('=')
+                                except ValueError:  # not a key=value line
+                                    continue
+                                if k == 'X-AppImage-Version':
+                                    branch = v.split('_')[0]
+                                    logging.debug(f"{branch=}")
+                                    break
                 p.send_signal(signal.SIGINT)
             p.poll()
         return branch

--- a/wine.py
+++ b/wine.py
@@ -112,7 +112,10 @@ def check_wine_version_and_branch(TESTBINARY):
     # Does not check for Staging. Will not implement: expecting merging of
     # commits in time.
     if config.TARGETVERSION == "10":
-        WINE_MINIMUM = [7, 18]
+        if utils.check_logos_release_version(config.current_logos_version, 30, 1):
+            WINE_MINIMUM = [7, 18]
+        else:
+            WINE_MINIMUM = [9, 10]
     elif config.TARGETVERSION == "9":
         WINE_MINIMUM = [7, 0]
     else:

--- a/wine.py
+++ b/wine.py
@@ -140,7 +140,7 @@ def check_wine_version_and_branch(TESTBINARY):
             return False, "Can't use Stable release"
         elif wine_release[0] < 7:
             return False, "Version is < 7.0"
-        elif wine_release[0] < 8:
+        elif wine_release[0] == 7:
             if (
                 "Proton" in TESTBINARY
                 or ("Proton" in os.path.realpath(TESTBINARY) if os.path.islink(TESTBINARY) else False)  # noqa: E501
@@ -152,12 +152,17 @@ def check_wine_version_and_branch(TESTBINARY):
             elif wine_release[1] < WINE_MINIMUM[1]:
                 reason = f"{'.'.join(wine_release)} is below minimum required, {'.'.join(WINE_MINIMUM)}"  # noqa: E501
                 return False, reason
-        elif wine_release[0] < 9:
+        elif wine_release[0] == 8:
             if wine_release[1] < 1:
                 return False, "Version is 8.0"
             elif wine_release[1] < 16:
                 if wine_release[2] != 'staging':
                     return False, "Version < 8.16 needs to be Staging release"
+        elif wine_release[0] == 9:
+            if wine_release[1] < 10:
+                return False, "Version < 9.10"
+        elif wine_release[0] > 9:
+            pass
     else:
         return False, error_message
 

--- a/wine.py
+++ b/wine.py
@@ -67,7 +67,6 @@ def heavy_wineserver_wait():
     utils.wait_process_using_dir(config.WINEPREFIX)
     wait_on([f"{config.WINESERVER_EXE}", "-w"])
 
-
 def get_wine_release(binary):
     cmd = [binary, "--version"]
     try:
@@ -425,8 +424,21 @@ def get_wine_env():
 
 
 def run_logos():
-    run_wine_proc(config.WINE_EXE, exe=config.LOGOS_EXE)
-    run_wine_proc(config.WINESERVER_EXE, exe_args=["-w"])
+    logos_release = utils.convert_logos_release(config.current_logos_version)
+    wine_release = get_wine_release(config.WINE_EXE)
+    
+    #TODO: Find a way to incorporate check_wine_version_and_branch()
+    if logos_release[0] < 30 and logos_release[0] > 9 and (wine_release[0] < 7 or (wine_release[0] == 7 and wine_release[1] < 18)):
+        txt = "Can't run Logos 10+ with Wine below 7.18."
+        logging.critical(txt)
+        msg.status(txt)
+    if logos_release[0] > 29 and wine_release[0] < 9 and wine_release[1] < 10:
+        txt = "Can't run Logos 30+ with Wine below 9.10."
+        logging.critical(txt)
+        msg.status(txt)
+    else:
+        run_wine_proc(config.WINE_EXE, exe=config.LOGOS_EXE)
+        run_wine_proc(config.WINESERVER_EXE, exe_args=["-w"])
 
 
 def run_indexing():


### PR DESCRIPTION
Should fix #121.

Also implements a check for the currently installed Logos version and sets the Logos 10 minimum Wine version appropriately.

We can then use this function in future code to add an update Logos routine for #116 or to display the current version in the TUI/GUI, etc.

It also fixes an issue with tui_dialog.tasklist and makes the TUI app display the currently installed Logos version.