### PR TITLE
Add log rotation. Fix #132.

### DIFF
--- a/network.py
+++ b/network.py
@@ -374,7 +374,6 @@ def get_latest_release_data(releases_url):
     if data:
         try:
             json_data = json.loads(data.decode())
-            # logging.debug(f"{json_data=}")  # omit to make log more readable
         except json.JSONDecodeError as e:
             logging.error(f"Error decoding JSON response: {e}")
             return None


### PR DESCRIPTION
Fixes #132 with gzipped rotation for logs of 10MB in size.