### PR TITLE
Campaign to Save the CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,52 @@
+import logging
+import threading
+import queue
+
+import config
+import installer
+import msg
+import utils
+
+
+class CLI:
+    def __init__(self):
+        self.running = True
+        self.choice_q = queue.Queue()
+        self.input_q = queue.Queue()
+        self.event = threading.Event()
+
+    def stop(self):
+        self.running = False
+
+    def run(self):
+        config.DIALOG = "cli"
+
+        self.thread = utils.start_thread(installer.ensure_launcher_shortcuts, daemon_bool=True, app=self)
+
+        while self.running:
+            self.user_input_processor()
+
+        msg.logos_msg("Exiting CLI installer.")
+
+
+    def user_input_processor(self):
+        prompt = None
+        question = None
+        options = None
+        choice = None
+        if self.input_q.qsize() > 0:
+            prompt = self.input_q.get()
+        if prompt is not None and isinstance(prompt, tuple):
+            question = prompt[0]
+            options = prompt[1]
+        if question is not None and options is not None:
+            choice = input(f"{question}: {options}: ")
+        if choice is not None and choice.lower() == 'exit':
+            self.running = False
+        if choice is not None:
+            self.choice_q.put(choice)
+            self.event.set()
+
+
+def command_line_interface():
+    CLI().run()

--- a/cli.py
+++ b/cli.py
@@ -1,56 +1,65 @@
-import logging
-import threading
+# import logging
 import queue
+import threading
 
 import config
 import installer
-import msg
+import logos
+# import msg
 import utils
 
 
 class CLI:
     def __init__(self):
+        config.DIALOG = "cli"
         self.running = True
         self.choice_q = queue.Queue()
         self.input_q = queue.Queue()
-        self.event = threading.Event()
+        self.input_event = threading.Event()
+        self.choice_event = threading.Event()
+        self.logos = logos.LogosManager(app=self)
 
     def stop(self):
         self.running = False
 
-    def run(self):
-        config.DIALOG = "cli"
+    def install_app(self):
+        self.thread = utils.start_thread(
+            installer.ensure_launcher_shortcuts,
+            app=self
+        )
+        self.user_input_processor()
 
-        self.thread = utils.start_thread(installer.ensure_launcher_shortcuts, daemon_bool=True, app=self)
+    def run_installed_app(self):
+        self.thread = utils.start_thread(self.logos.start, app=self)
 
+    def user_input_processor(self, evt=None):
         while self.running:
-            self.user_input_processor()
-
-        msg.logos_msg("Exiting CLI installer.")
-
-    def user_input_processor(self):
-        prompt = None
-        question = None
-        options = None
-        choice = None
-        if self.input_q.qsize() > 0:
+            prompt = None
+            question = None
+            options = None
+            choice = None
+            # Wait for next input queue item.
+            self.input_event.wait()
+            self.input_event.clear()
             prompt = self.input_q.get()
-        if prompt is not None and isinstance(prompt, tuple):
-            question = prompt[0]
-            options = prompt[1]
-        if question is not None and options is not None:
-            # Convert options list to string.
-            default = options[0]
-            options[0] = f"{options[0]} [default]"
-            optstr = ', '.join(options)
-            choice = input(f"{question}: {optstr}: ")
-            if len(choice) == 0:
-                choice = default
-        if choice is not None and choice.lower() == 'exit':
-            self.running = False
-        if choice is not None:
-            self.choice_q.put(choice)
-            self.event.set()
+            if prompt is None:
+                return
+            if prompt is not None and isinstance(prompt, tuple):
+                question = prompt[0]
+                options = prompt[1]
+            if question is not None and options is not None:
+                # Convert options list to string.
+                default = options[0]
+                options[0] = f"{options[0]} [default]"
+                optstr = ', '.join(options)
+                choice = input(f"{question}: {optstr}: ")
+                if len(choice) == 0:
+                    choice = default
+            if choice is not None and choice.lower() == 'exit':
+                self.running = False
+            if choice is not None:
+                self.choice_q.put(choice)
+                self.choice_event.set()
 
 
 def command_line_interface():

--- a/cli.py
+++ b/cli.py
@@ -32,6 +32,9 @@ class CLI:
     def run_installed_app(self):
         self.logos.start()
 
+    def set_appimage(self):
+        utils.set_appimage_symlink(app=self)
+
     def user_input_processor(self, evt=None):
         while self.running:
             prompt = None
@@ -62,5 +65,13 @@ class CLI:
                 self.choice_event.set()
 
 
-def command_line_interface():
-    CLI().run()
+def install_app():
+    CLI().install_app()
+
+
+def run_installed_app():
+    CLI().run_installed_app()
+
+
+def set_appimage():
+    CLI().set_appimage()

--- a/cli.py
+++ b/cli.py
@@ -123,6 +123,9 @@ def backup():
 
 
 def create_shortcuts():
+    # TODO: This takes surprisingly long because it walks through all the
+    # installer steps to confirm everything up to the shortcuts. Can this be
+    # shortcutted?
     CLI().install_app()
 
 

--- a/cli.py
+++ b/cli.py
@@ -30,7 +30,7 @@ class CLI:
         self.user_input_processor()
 
     def run_installed_app(self):
-        self.thread = utils.start_thread(self.logos.start, app=self)
+        self.logos.start()
 
     def user_input_processor(self, evt=None):
         while self.running:

--- a/cli.py
+++ b/cli.py
@@ -28,7 +28,6 @@ class CLI:
 
         msg.logos_msg("Exiting CLI installer.")
 
-
     def user_input_processor(self):
         prompt = None
         question = None
@@ -40,7 +39,13 @@ class CLI:
             question = prompt[0]
             options = prompt[1]
         if question is not None and options is not None:
-            choice = input(f"{question}: {options}: ")
+            # Convert options list to string.
+            default = options[0]
+            options[0] = f"{options[0]} [default]"
+            optstr = ', '.join(options)
+            choice = input(f"{question}: {optstr}: ")
+            if len(choice) == 0:
+                choice = default
         if choice is not None and choice.lower() == 'exit':
             self.running = False
         if choice is not None:

--- a/cli.py
+++ b/cli.py
@@ -3,9 +3,11 @@ import queue
 import threading
 
 import config
+import control
 import installer
 import logos
 # import msg
+import wine
 import utils
 
 
@@ -19,8 +21,14 @@ class CLI:
         self.choice_event = threading.Event()
         self.logos = logos.LogosManager(app=self)
 
-    def stop(self):
-        self.running = False
+    def backup(self):
+        control.backup()
+
+    def edit_config(self):
+        control.edit_config()
+
+    def get_winetricks(self):
+        control.set_winetricks()
 
     def install_app(self):
         self.thread = utils.start_thread(
@@ -29,11 +37,53 @@ class CLI:
         )
         self.user_input_processor()
 
+    def install_d3d_compiler(self):
+        wine.install_d3d_compiler()
+
+    def install_dependencies(self):
+        utils.check_dependencies()
+
+    def install_fonts(self):
+        wine.install_fonts()
+
+    def install_icu(self):
+        wine.install_icu_data_files()
+
+    def remove_index_files(self):
+        control.remove_all_index_files()
+
+    def remove_install_dir(self):
+        control.remove_install_dir()
+
+    def remove_library_catalog(self):
+        control.remove_library_catalog()
+
+    def restore(self):
+        control.restore()
+
+    def run_indexing(self):
+        self.logos.index()
+
     def run_installed_app(self):
         self.logos.start()
 
+    def run_winetricks(self):
+        wine.run_winetricks()
+
     def set_appimage(self):
         utils.set_appimage_symlink(app=self)
+
+    def stop(self):
+        self.running = False
+
+    def toggle_app_logging(self):
+        self.logos.switch_logging()
+
+    def update_latest_appimage(self):
+        utils.update_to_latest_recommended_appimage()
+
+    def update_self(self):
+        utils.update_to_latest_lli_release()
 
     def user_input_processor(self, evt=None):
         while self.running:
@@ -65,13 +115,84 @@ class CLI:
                 self.choice_event.set()
 
 
+# NOTE: These subcommands are outside the CLI class so that the class can be
+# instantiated at the moment the subcommand is run. This lets any CLI-specific
+# code get executed along with the subcommand.
+def backup():
+    CLI().backup()
+
+
+def create_shortcuts():
+    CLI().install_app()
+
+
+def edit_config():
+    CLI().edit_config()
+
+
+def get_winetricks():
+    CLI().get_winetricks()
+
+
 def install_app():
     CLI().install_app()
+
+
+def install_d3d_compiler():
+    CLI().install_d3d_compiler()
+
+
+def install_dependencies():
+    CLI().install_dependencies()
+
+
+def install_fonts():
+    CLI().install_fonts()
+
+
+def install_icu():
+    CLI().install_icu()
+
+
+def remove_index_files():
+    CLI().remove_index_files()
+
+
+def remove_install_dir():
+    CLI().remove_install_dir()
+
+
+def remove_library_catalog():
+    CLI().remove_library_catalog()
+
+
+def restore():
+    CLI().restore()
+
+
+def run_indexing():
+    CLI().run_indexing()
 
 
 def run_installed_app():
     CLI().run_installed_app()
 
 
+def run_winetricks():
+    CLI().run_winetricks()
+
+
 def set_appimage():
     CLI().set_appimage()
+
+
+def toggle_app_logging():
+    CLI().toggle_app_logging()
+
+
+def update_latest_appimage():
+    CLI().update_latest_appimage()
+
+
+def update_self():
+    CLI().update_self()

--- a/control.py
+++ b/control.py
@@ -211,6 +211,7 @@ def copy_data(src_dirs, dst_dir):
 
 def remove_install_dir():
     folder = Path(config.INSTALLDIR)
+    # FIXME: msg.cli_question needs additional arg
     if (
         folder.is_dir()
         and msg.cli_question(f"Delete \"{folder}\" and all its contents?")

--- a/gui_app.py
+++ b/gui_app.py
@@ -759,7 +759,8 @@ class ControlWindow():
         appimage_filename = self.open_file_dialog("AppImage", "AppImage")
         if not appimage_filename:
             return
-        config.SELECTED_APPIMAGE_FILENAME = appimage_filename
+        # config.SELECTED_APPIMAGE_FILENAME = appimage_filename
+        config.APPIMAGE_FILE_PATH = appimage_filename
         utils.start_thread(utils.set_appimage_symlink, app=self)
 
     def get_winetricks(self, evt=None):

--- a/installer.py
+++ b/installer.py
@@ -522,7 +522,8 @@ def ensure_wineprefix_init(app=None):
             logging.debug("Initializing wineprefix.")
             process = wine.initializeWineBottle()
             wine.wait_pid(process)
-            wine.light_wineserver_wait()
+            # wine.light_wineserver_wait()
+            wine.wineserver_wait()
             logging.debug("Wine init complete.")
     logging.debug(f"> {init_file} exists?: {init_file.is_file()}")
 
@@ -580,7 +581,8 @@ def ensure_winetricks_applied(app=None):
 
         msg.logos_msg(f"Setting {config.FLPRODUCT} Bible Indexing to Win10 Mode…")  # noqa: E501
         wine.set_win_version("indexer", "win10")
-        wine.light_wineserver_wait()
+        # wine.light_wineserver_wait()
+        wine.wineserver_wait()
     logging.debug("> Done.")
 
 

--- a/installer.py
+++ b/installer.py
@@ -15,8 +15,6 @@ import wine
 # To replicate, start a TUI install, return/cancel on second step
 # Then launch a new install
 
-# TODO: Reimplement `--install-app`?
-
 
 def ensure_product_choice(app=None):
     config.INSTALL_STEPS_COUNT += 1
@@ -27,13 +25,16 @@ def ensure_product_choice(app=None):
 
     if not config.FLPRODUCT:
         if app:
-            utils.send_task(app, 'FLPRODUCT')
-            if config.DIALOG == 'curses':
-                app.product_e.wait()
-            config.FLPRODUCT = app.product_q.get()
-        else:
-            m = f"{utils.get_calling_function_name()}: --install-app is broken"
-            logging.critical(m)
+            if config.DIALOG == 'cli':
+                app.input_q.put(("Choose which FaithLife product the script should install: ", ["Logos", "Verbum", "Exit"]))
+                app.event.wait()
+                app.event.clear()
+                config.FLPRODUCT = app.choice_q.get()
+            else:
+                utils.send_task(app, 'FLPRODUCT')
+                if config.DIALOG == 'curses':
+                    app.product_e.wait()
+                config.FLPRODUCT = app.product_q.get()
     else:
         if config.DIALOG == 'curses':
             app.set_product(config.FLPRODUCT)
@@ -58,13 +59,16 @@ def ensure_version_choice(app=None):
     logging.debug('- config.TARGETVERSION')
     if not config.TARGETVERSION:
         if app:
-            utils.send_task(app, 'TARGETVERSION')
-            if config.DIALOG == 'curses':
-                app.version_e.wait()
-            config.TARGETVERSION = app.version_q.get()
-        else:
-            m = f"{utils.get_calling_function_name()}: --install-app is broken"
-            logging.critical(m)
+            if config.DIALOG == 'cli':
+                app.input_q.put((f"Which version of {config.FLPRODUCT} should the script install?: ", ["10", "9", "Exit"]))
+                app.event.wait()
+                app.event.clear()
+                config.TARGETVERSION = app.choice_q.get()
+            else:
+                utils.send_task(app, 'TARGETVERSION')
+                if config.DIALOG == 'curses':
+                    app.version_e.wait()
+                config.TARGETVERSION = app.version_q.get()
     else:
         if config.DIALOG == 'curses':
             app.set_version(config.TARGETVERSION)
@@ -81,14 +85,19 @@ def ensure_release_choice(app=None):
 
     if not config.TARGET_RELEASE_VERSION:
         if app:
-            utils.send_task(app, 'TARGET_RELEASE_VERSION')
-            if config.DIALOG == 'curses':
-                app.release_e.wait()
-            config.TARGET_RELEASE_VERSION = app.release_q.get()
-            logging.debug(f"{config.TARGET_RELEASE_VERSION=}")
-        else:
-            m = f"{utils.get_calling_function_name()}: --install-app is broken"
-            logging.critical(m)
+            if config.DIALOG == 'cli':
+                utils.start_thread(network.get_logos_releases, daemon_bool=True, app=app)
+                app.event.wait()
+                app.event.clear()
+                app.event.wait()  # Wait for user input queue to receive input
+                app.event.clear()
+                config.TARGET_RELEASE_VERSION = app.choice_q.get()
+            else:
+                utils.send_task(app, 'TARGET_RELEASE_VERSION')
+                if config.DIALOG == 'curses':
+                    app.release_e.wait()
+                config.TARGET_RELEASE_VERSION = app.release_q.get()
+                logging.debug(f"{config.TARGET_RELEASE_VERSION=}")
     else:
         if config.DIALOG == 'curses':
             app.set_release(config.TARGET_RELEASE_VERSION)
@@ -109,17 +118,20 @@ def ensure_install_dir_choice(app=None):
     default = f"{str(Path.home())}/{config.FLPRODUCT}Bible{config.TARGETVERSION}"  # noqa: E501
     if not config.INSTALLDIR:
         if app:
-            if config.DIALOG == 'tk':
+            if config.DIALOG == 'cli':
+                default = f"{str(Path.home())}/{config.FLPRODUCT}Bible{config.TARGETVERSION}"  # noqa: E501
+                question = f"Where should {config.FLPRODUCT} files be installed to?: "  # noqa: E501
+                app.input_q.put((question, [default, "Type your own custom path", "Exit"]))
+                app.event.wait()
+                app.event.clear()
+                config.INSTALLDIR = app.choice_q.get()
+            elif config.DIALOG == 'tk':
                 config.INSTALLDIR = default
-                config.APPDIR_BINDIR = f"{config.INSTALLDIR}/data/bin"
             elif config.DIALOG == 'curses':
                 utils.send_task(app, 'INSTALLDIR')
                 app.installdir_e.wait()
                 config.INSTALLDIR = app.installdir_q.get()
-                config.APPDIR_BINDIR = f"{config.INSTALLDIR}/data/bin"
-        else:
-            m = f"{utils.get_calling_function_name()}: --install-app is broken"
-            logging.critical(m)
+            config.APPDIR_BINDIR = f"{config.INSTALLDIR}/data/bin"
     else:
         if config.DIALOG == 'curses':
             app.set_installdir(config.INSTALLDIR)
@@ -143,13 +155,23 @@ def ensure_wine_choice(app=None):
     if utils.get_wine_exe_path() is None:
         network.set_recommended_appimage_config()
         if app:
-            utils.send_task(app, 'WINE_EXE')
-            if config.DIALOG == 'curses':
-                app.wine_e.wait()
-            config.WINE_EXE = app.wine_q.get()
-        else:
-            m = f"{utils.get_calling_function_name()}: --install-app is broken"
-            logging.critical(m)
+            if config.DIALOG == 'cli':
+                options = utils.get_wine_options(
+                    utils.find_appimage_files(config.TARGET_RELEASE_VERSION),
+                    utils.find_wine_binary_files(config.TARGET_RELEASE_VERSION)
+                )
+                if config.DIALOG == 'cli':
+                    app.input_q.put((
+                        f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.TARGET_RELEASE_VERSION} in {config.INSTALLDIR}?: ", options))
+                    app.event.set()
+                app.event.wait()
+                app.event.clear()
+                config.WINE_EXE = utils.get_relative_path(utils.get_config_var(app.choice_q.get()), config.INSTALLDIR)
+            else:
+                utils.send_task(app, 'WINE_EXE')
+                if config.DIALOG == 'curses':
+                    app.wine_e.wait()
+                config.WINE_EXE = app.wines_q.get()
     else:
         if config.DIALOG == 'curses':
             app.set_wine(utils.get_wine_exe_path())
@@ -177,12 +199,28 @@ def ensure_winetricks_choice(app=None):
     update_install_feedback("Choose winetricks binary…", app=app)
     logging.debug('- config.WINETRICKSBIN')
 
-    if app:
-        if config.WINETRICKSBIN is None:
-            utils.send_task(app, 'WINETRICKSBIN')
-            if config.DIALOG == 'curses':
-                app.tricksbin_e.wait()
-            config.WINETRICKSBIN = app.tricksbin_q.get()
+    if config.WINETRICKSBIN is None:
+        # Check if local winetricks version available; else, download it.
+        config.WINETRICKSBIN = f"{config.APPDIR_BINDIR}/winetricks"
+
+        winetricks_options = utils.get_winetricks_options()
+
+        if app:
+            if config.DIALOG == 'cli':
+                app.input_q.put((f"Should the script use the system's local winetricks or download the latest winetricks from the Internet? The script needs to set some Wine options that {config.FLPRODUCT} requires on Linux.", winetricks_options))
+                app.event.wait()
+                app.event.clear()
+                winetricksbin = app.choice_q.get()
+            else:
+                utils.send_task(app, 'WINETRICKSBIN')
+                if config.DIALOG == 'curses':
+                    app.tricksbin_e.wait()
+                winetricksbin = app.tricksbin_q.get()
+
+        if not winetricksbin.startswith('Download'):
+            config.WINETRICKSBIN = winetricksbin
+        else:
+            config.WINETRICKSBIN = winetricks_options[0]
     else:
         m = f"{utils.get_calling_function_name()}: --install-app is broken"
         logging.critical(m)
@@ -241,7 +279,10 @@ def ensure_installation_config(app=None):
     logging.debug(f"> {config.LOGOS64_URL=}")
 
     if app:
-        utils.send_task(app, 'INSTALL')
+        if config.DIALOG == 'cli':
+            msg.logos_msg("Install is running…")
+        else:
+            utils.send_task(app, 'INSTALL')
 
 
 def ensure_install_dirs(app=None):
@@ -274,10 +315,10 @@ def ensure_install_dirs(app=None):
     logging.debug(f"> {config.WINEPREFIX=}")
 
     if app:
-        utils.send_task(app, 'INSTALLING')
-    else:
-        m = f"{utils.get_calling_function_name()}: --install-app is broken"
-        logging.critical(m)
+        if config.DIALOG == 'cli':
+            pass
+        else:
+            utils.send_task(app, 'INSTALLING')
 
 
 def ensure_sys_deps(app=None):
@@ -608,18 +649,24 @@ def ensure_config_file(app=None):
 
         if different:
             if app:
-                utils.send_task(app, 'CONFIG')
-                if config.DIALOG == 'curses':
-                    app.config_e.wait()
-            elif msg.logos_acknowledge_question(
-                f"Update config file at {config.CONFIG_FILE}?",
-                "The existing config file was not overwritten."
-            ):
-                logging.info("Updating config file.")
-                utils.write_config(config.CONFIG_FILE)
+                if config.DIALOG == 'cli':
+                    if msg.logos_acknowledge_question(
+                        f"Update config file at {config.CONFIG_FILE}?",
+                        "The existing config file was not overwritten.",
+                        ""
+                    ):
+                        logging.info("Updating config file.")
+                        utils.write_config(config.CONFIG_FILE)
+                else:
+                    utils.send_task(app, 'CONFIG')
+                    if config.DIALOG == 'curses':
+                        app.config_e.wait()
 
     if app:
-        utils.send_task(app, 'DONE')
+        if config.DIALOG == 'cli':
+            msg.logos_msg("Install has finished.")
+        else:
+            utils.send_task(app, 'DONE')
 
     logging.debug(f"> File exists?: {config.CONFIG_FILE}: {Path(config.CONFIG_FILE).is_file()}")  # noqa: E501
 
@@ -697,11 +744,14 @@ Categories=Education;
             fpath = Path.home() / '.local' / 'share' / 'applications' / f
             logging.debug(f"> File exists?: {fpath}: {fpath.is_file()}")
     else:
-        logging.debug("Running from source. Skipping launcher creation.")
         update_install_feedback(
             "Running from source. Skipping launcher creation.",
             app=app
         )
+
+    if app:
+        if config.DIALOG == 'cli':
+            app.stop()
 
 
 def update_install_feedback(text, app=None):

--- a/installer.py
+++ b/installer.py
@@ -162,10 +162,8 @@ def ensure_wine_choice(app=None):
                     utils.find_appimage_files(config.TARGET_RELEASE_VERSION),
                     utils.find_wine_binary_files(config.TARGET_RELEASE_VERSION)
                 )
-                if config.DIALOG == 'cli':
-                    app.input_q.put((
-                        f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.TARGET_RELEASE_VERSION} in {config.INSTALLDIR}?: ", options))
-                    app.input_event.set()
+                app.input_q.put((
+                    f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.TARGET_RELEASE_VERSION} in {config.INSTALLDIR}?: ", options))
                 app.input_event.set()
                 app.choice_event.wait()
                 app.choice_event.clear()

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ def get_parser():
         help='skip font installations',
     )
     cfg.add_argument(
+        # TODO: Make this a hidden option?
         '-W', '--skip-winetricks', action='store_true',
         help='skip winetricks installations. For development purposes only!!!',
     )
@@ -181,6 +182,7 @@ def get_parser():
         help='[re-]create app shortcuts',
     )
     cmd.add_argument(
+        # TODO: Make this a hidden option?
         '--remove-install-dir', action='store_true',
         help='delete the current installation folder',
     )

--- a/main.py
+++ b/main.py
@@ -241,7 +241,7 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'install_app': run_cli,
+        'install_app': cli.CLI().install_app,
         'run_installed_app': logos.LogosManager().start,
         'run_indexing': logos.LogosManager().index,
         'remove_library_catalog': control.remove_library_catalog,
@@ -285,10 +285,6 @@ def parse_args(args, parser):
     if config.ACTION is None:
         config.ACTION = run_control_panel
     logging.debug(f"{config.ACTION=}")
-
-
-def run_cli():
-    cli.command_line_interface()
 
 
 def run_control_panel():

--- a/main.py
+++ b/main.py
@@ -246,26 +246,26 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'install_app': cli.install_app,
-        'run_installed_app': cli.run_installed_app,
-        'run_indexing': logos.LogosManager().index,
-        'remove_library_catalog': control.remove_library_catalog,
-        'remove_index_files': control.remove_all_index_files,
-        'edit_config': control.edit_config,
-        'install_dependencies': utils.check_dependencies,
         'backup': control.backup,
-        'restore': control.restore,
-        'update_self': utils.update_to_latest_lli_release,
-        'update_latest_appimage': utils.update_to_latest_recommended_appimage,
-        'set_appimage': cli.set_appimage,
+        'create_shortcuts': installer.ensure_launcher_shortcuts,
+        'edit_config': control.edit_config,
         'get_winetricks': control.set_winetricks,
-        'run_winetricks': wine.run_winetricks,
+        'install_app': cli.install_app,
         'install_d3d_compiler': wine.install_d3d_compiler,
+        'install_dependencies': utils.check_dependencies,
         'install_fonts': wine.install_fonts,
         'install_icu': wine.install_icu_data_files,
-        'toggle_app_logging': logos.LogosManager().switch_logging,
-        'create_shortcuts': installer.ensure_launcher_shortcuts,
+        'remove_index_files': control.remove_all_index_files,
         'remove_install_dir': control.remove_install_dir,
+        'remove_library_catalog': control.remove_library_catalog,
+        'restore': control.restore,
+        'run_indexing': logos.LogosManager().index,
+        'run_installed_app': cli.run_installed_app,
+        'run_winetricks': wine.run_winetricks,
+        'set_appimage': cli.set_appimage,
+        'toggle_app_logging': logos.LogosManager().switch_logging,
+        'update_self': utils.update_to_latest_lli_release,
+        'update_latest_appimage': utils.update_to_latest_recommended_appimage,
     }
 
     config.ACTION = None
@@ -414,13 +414,17 @@ def main():
     install_required = [
         'backup',
         'create_shortcuts',
-        'remove_all_index_files',
+        'install_d3d_compiler',
+        'install_fonts',
+        'install_icu',
+        'remove_index_files',
         'remove_library_catalog',
         'restore',
         'run_indexing',
         'run_installed_app',
-        'run_logos',
-        'switch_logging',
+        'run_winetricks',
+        'set_appimage',
+        'toggle_app_logging',
     ]
     if config.ACTION == "disabled":
         msg.logos_error("That option is disabled.", "info")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import argparse
+
+import cli
 import config
 import control
 import curses
@@ -239,7 +241,7 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'install_app': installer.ensure_launcher_shortcuts,
+        'install_app': run_cli,
         'run_installed_app': logos.LogosManager().start,
         'run_indexing': logos.LogosManager().index,
         'remove_library_catalog': control.remove_library_catalog,
@@ -283,6 +285,10 @@ def parse_args(args, parser):
     if config.ACTION is None:
         config.ACTION = run_control_panel
     logging.debug(f"{config.ACTION=}")
+
+
+def run_cli():
+    cli.command_line_interface()
 
 
 def run_control_panel():

--- a/main.py
+++ b/main.py
@@ -246,26 +246,26 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'backup': control.backup,
-        'create_shortcuts': installer.ensure_launcher_shortcuts,
-        'edit_config': control.edit_config,
-        'get_winetricks': control.set_winetricks,
+        'backup': cli.backup,
+        'create_shortcuts': cli.create_shortcuts,
+        'edit_config': cli.edit_config,
+        'get_winetricks': cli.get_winetricks,
         'install_app': cli.install_app,
-        'install_d3d_compiler': wine.install_d3d_compiler,
-        'install_dependencies': utils.check_dependencies,
-        'install_fonts': wine.install_fonts,
-        'install_icu': wine.install_icu_data_files,
-        'remove_index_files': control.remove_all_index_files,
-        'remove_install_dir': control.remove_install_dir,
-        'remove_library_catalog': control.remove_library_catalog,
-        'restore': control.restore,
-        'run_indexing': logos.LogosManager().index,
+        'install_d3d_compiler': cli.install_d3d_compiler,
+        'install_dependencies': cli.install_dependencies,
+        'install_fonts': cli.install_fonts,
+        'install_icu': cli.install_icu,
+        'remove_index_files': cli.remove_index_files,
+        'remove_install_dir': cli.remove_install_dir,
+        'remove_library_catalog': cli.remove_library_catalog,
+        'restore': cli.restore,
+        'run_indexing': cli.run_indexing,
         'run_installed_app': cli.run_installed_app,
-        'run_winetricks': wine.run_winetricks,
+        'run_winetricks': cli.run_winetricks,
         'set_appimage': cli.set_appimage,
-        'toggle_app_logging': logos.LogosManager().switch_logging,
-        'update_self': utils.update_to_latest_lli_release,
-        'update_latest_appimage': utils.update_to_latest_recommended_appimage,
+        'toggle_app_logging': cli.toggle_app_logging,
+        'update_self': cli.update_self,
+        'update_latest_appimage': cli.update_latest_appimage,
     }
 
     config.ACTION = None
@@ -433,7 +433,7 @@ def main():
         config.ACTION()
     elif utils.app_is_installed():
         # Run the desired Logos action.
-        logging.info(f"Running function for installed app: {config.ACTION.__name__}")  # noqa: E501
+        logging.info(f"Running function for {config.FLPRODUCT}: {config.ACTION.__name__}")  # noqa: E501
         config.ACTION()  # defaults to run_control_panel()
     else:
         logging.info("Starting Control Panel")

--- a/main.py
+++ b/main.py
@@ -213,6 +213,9 @@ def parse_args(args, parser):
     if args.delete_log:
         config.DELETE_LOG = True
 
+    if args.set_appimage:
+        config.APPIMAGE_FILE_PATH = args.set_appimage[0]
+
     if args.skip_fonts:
         config.SKIP_FONTS = True
 
@@ -243,8 +246,8 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'install_app': install_app,
-        'run_installed_app': run_installed_app,
+        'install_app': cli.install_app,
+        'run_installed_app': cli.run_installed_app,
         'run_indexing': logos.LogosManager().index,
         'remove_library_catalog': control.remove_library_catalog,
         'remove_index_files': control.remove_all_index_files,
@@ -254,7 +257,7 @@ def parse_args(args, parser):
         'restore': control.restore,
         'update_self': utils.update_to_latest_lli_release,
         'update_latest_appimage': utils.update_to_latest_recommended_appimage,
-        'set_appimage': utils.set_appimage_symlink,
+        'set_appimage': cli.set_appimage,
         'get_winetricks': control.set_winetricks,
         'run_winetricks': wine.run_winetricks,
         'install_d3d_compiler': wine.install_d3d_compiler,
@@ -287,17 +290,6 @@ def parse_args(args, parser):
     if config.ACTION is None:
         config.ACTION = run_control_panel
     logging.debug(f"{config.ACTION=}")
-
-
-# NOTE: install_app() and run_installed_app() have to be explicit functions to
-# avoid instantiating cli.CLI() when CLI is not being run. Otherwise,
-# config.DIALOG is incorrectly set as 'cli'.
-def install_app():
-    cli.CLI().install_app()
-
-
-def run_installed_app():
-    cli.CLI().run_installed_app()
 
 
 def run_control_panel():

--- a/main.py
+++ b/main.py
@@ -243,8 +243,8 @@ def parse_args(args, parser):
 
     # Set ACTION function.
     actions = {
-        'install_app': cli.CLI().install_app,
-        'run_installed_app': cli.CLI().run_installed_app,
+        'install_app': install_app,
+        'run_installed_app': run_installed_app,
         'run_indexing': logos.LogosManager().index,
         'remove_library_catalog': control.remove_library_catalog,
         'remove_index_files': control.remove_all_index_files,
@@ -287,6 +287,17 @@ def parse_args(args, parser):
     if config.ACTION is None:
         config.ACTION = run_control_panel
     logging.debug(f"{config.ACTION=}")
+
+
+# NOTE: install_app() and run_installed_app() have to be explicit functions to
+# avoid instantiating cli.CLI() when CLI is not being run. Otherwise,
+# config.DIALOG is incorrectly set as 'cli'.
+def install_app():
+    cli.CLI().install_app()
+
+
+def run_installed_app():
+    cli.CLI().run_installed_app()
 
 
 def run_control_panel():

--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ def parse_args(args, parser):
     # Set ACTION function.
     actions = {
         'install_app': cli.CLI().install_app,
-        'run_installed_app': logos.LogosManager().start,
+        'run_installed_app': cli.CLI().run_installed_app,
         'run_indexing': logos.LogosManager().index,
         'remove_library_catalog': control.remove_library_catalog,
         'remove_index_files': control.remove_all_index_files,
@@ -413,6 +413,7 @@ def main():
         'remove_library_catalog',
         'restore',
         'run_indexing',
+        'run_installed_app',
         'run_logos',
         'switch_logging',
     ]
@@ -423,7 +424,7 @@ def main():
         config.ACTION()
     elif utils.app_is_installed():
         # Run the desired Logos action.
-        logging.info(f"Running function: {config.ACTION.__name__}")
+        logging.info(f"Running function for installed app: {config.ACTION.__name__}")  # noqa: E501
         config.ACTION()  # defaults to run_control_panel()
     else:
         logging.info("Starting Control Panel")

--- a/main.py
+++ b/main.py
@@ -448,10 +448,12 @@ def close():
     logging.debug("Closing Logos on Linux.")
     for thread in threads:
         thread.join()
-    if len(processes) > 0:
+    # Only kill wine processes if closing the Control Panel. Otherwise, some
+    # CLI commands get killed as soon as they're started.
+    if config.ACTION.__name__ == 'run_control_panel' and len(processes) > 0:
         wine.end_wine_processes()
     else:
-        logging.debug("No processes found.")
+        logging.debug("No extra processes found.")
     logging.debug("Closing Logos on Linux finished.")
 
 

--- a/msg.py
+++ b/msg.py
@@ -246,7 +246,7 @@ def cli_ask_filepath(question_text):
 def logos_continue_question(question_text, no_text, secondary, app=None):
     if config.DIALOG == 'tk':
         gui_continue_question(question_text, no_text, secondary)
-    elif app is None:
+    elif config.DIALOG == 'cli':
         cli_continue_question(question_text, no_text, secondary)
     elif config.DIALOG == 'curses':
         app.screen_q.put(

--- a/msg.py
+++ b/msg.py
@@ -226,9 +226,9 @@ def gui_continue_question(question_text, no_text, secondary):
         logos_error(no_text)
 
 
-def cli_acknowledge_question(QUESTION_TEXT, NO_TEXT):
-    if not cli_question(QUESTION_TEXT):
-        logos_msg(NO_TEXT)
+def cli_acknowledge_question(question_text, no_text, secondary):
+    if not cli_question(question_text, secondary):
+        logos_msg(no_text)
         return False
     else:
         return True
@@ -264,11 +264,11 @@ def logos_continue_question(question_text, no_text, secondary, app=None):
         logos_error(f"Unhandled question: {question_text}")
 
 
-def logos_acknowledge_question(question_text, no_text):
+def logos_acknowledge_question(question_text, no_text, secondary):
     if config.DIALOG == 'curses':
         pass
     else:
-        return cli_acknowledge_question(question_text, no_text)
+        return cli_acknowledge_question(question_text, no_text, secondary)
 
 
 def get_progress_str(percent):

--- a/network.py
+++ b/network.py
@@ -546,11 +546,15 @@ def get_logos_releases(app=None):
     filtered_releases = releases
 
     if app:
-        app.releases_q.put(filtered_releases)
         if config.DIALOG == 'tk':
+            app.releases_q.put(filtered_releases)
             app.root.event_generate(app.release_evt)
         elif config.DIALOG == 'curses':
+            app.releases_q.put(filtered_releases)
             app.releases_e.set()
+        elif config.DIALOG == 'cli':
+            app.input_q.put((f"Which version of {config.FLPRODUCT} {config.TARGETVERSION} do you want to install?: ", filtered_releases))
+            app.event.set()
     return filtered_releases
 
 

--- a/network.py
+++ b/network.py
@@ -550,7 +550,7 @@ def get_logos_releases(app=None):
             app.releases_e.set()
         elif config.DIALOG == 'cli':
             app.input_q.put((f"Which version of {config.FLPRODUCT} {config.TARGETVERSION} do you want to install?: ", filtered_releases))
-            app.event.set()
+            app.input_event.set()
     return filtered_releases
 
 

--- a/network.py
+++ b/network.py
@@ -44,10 +44,9 @@ class FileProps(Props):
     def get_md5(self):
         if self.path is None:
             return
-        logging.debug("This may take a while…")
         md5 = hashlib.md5()
         with self.path.open('rb') as f:
-            for chunk in iter(lambda: f.read(4096), b''):
+            for chunk in iter(lambda: f.read(524288), b''):
                 md5.update(chunk)
         self.md5 = b64encode(md5.digest()).decode('utf-8')
         logging.debug(f"{str(self.path)} MD5: {self.md5}")
@@ -349,9 +348,6 @@ def same_md5(url, file_path):
     if url_md5 is None:  # skip MD5 check if not provided with URL
         res = True
     else:
-        # TODO: Figure out why this is taking a long time.
-        # On 20240922, I ran into an issue such that it would take
-        # upwards of 6.5 minutes to complete
         file_md5 = FileProps(file_path).get_md5()
         logging.debug(f"{file_md5=}")
         res = url_md5 == file_md5

--- a/network.py
+++ b/network.py
@@ -138,6 +138,8 @@ def cli_download(uri, destination, app=None):
     cli_queue = queue.Queue()
     kwargs = {'q': cli_queue, 'target': target}
     t = utils.start_thread(net_get, uri, **kwargs)
+    # TODO: This results in high CPU usage while showing the progress bar.
+    # The solution will be to rework the wait on the cli_queue.
     try:
         while t.is_alive():
             if cli_queue.empty():

--- a/system.py
+++ b/system.py
@@ -738,6 +738,8 @@ def install_dependencies(packages, bad_packages, logos9_packages=None, app=None)
             app.manualinstall_e.wait()
 
         if not install_deps_failed and not manual_install_required:
+            if config.DIALOG == 'cli':
+                command_str = command_str.replace("pkexec", "sudo")
             try:
                 logging.debug(f"Attempting to run this command: {command_str}")
                 run_command(command_str, shell=True)

--- a/system.py
+++ b/system.py
@@ -282,8 +282,8 @@ def get_dialog():
     # Set config.DIALOG.
     if dialog is not None:
         dialog = dialog.lower()
-        if dialog not in ['curses', 'tk']:
-            msg.logos_error("Valid values for DIALOG are 'curses' or 'tk'.")
+        if dialog not in ['cli', 'curses', 'tk']:
+            msg.logos_error("Valid values for DIALOG are 'cli', 'curses' or 'tk'.")  # noqa: E501
         config.DIALOG = dialog
     elif sys.__stdin__.isatty():
         config.DIALOG = 'curses'
@@ -780,8 +780,9 @@ def have_lib(library, ld_library_path):
     available_library_paths = ['/usr/lib', '/lib']
     if ld_library_path is not None:
         available_library_paths = [*ld_library_path.split(':'), *available_library_paths]
-        roots = [root for root in available_library_paths if not Path(root).is_symlink()]
-        logging.debug(f"Library Paths: {roots}")
+
+    roots = [root for root in available_library_paths if not Path(root).is_symlink()]
+    logging.debug(f"Library Paths: {roots}")
     for root in roots:
         libs = []
         logging.debug(f"Have lib? Checking {root}")
@@ -796,7 +797,7 @@ def have_lib(library, ld_library_path):
 
 
 def check_libs(libraries, app=None):
-    ld_library_path = os.environ.get('LD_LIBRARY_PATH', '')
+    ld_library_path = os.environ.get('LD_LIBRARY_PATH')
     for library in libraries:
         have_lib_result = have_lib(library, ld_library_path)
         if have_lib_result:

--- a/system.py
+++ b/system.py
@@ -183,33 +183,33 @@ def popen_command(command, retries=1, delay=0, **kwargs):
     return None
 
 
-def wait_on(command):
-    try:
-        # Start the process in the background
-        # TODO: Convert to use popen_command()
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True
-        )
-        msg.status(f"Waiting on \"{' '.join(command)}\" to finish.", end='')
-        time.sleep(1.0)
-        while process.poll() is None:
-            msg.logos_progress()
-            time.sleep(0.5)
-        print()
+# def wait_on(command):
+#     try:
+#         # Start the process in the background
+#         # TODO: Convert to use popen_command()
+#         process = subprocess.Popen(
+#             command,
+#             stdout=subprocess.PIPE,
+#             stderr=subprocess.PIPE,
+#             text=True
+#         )
+#         msg.status(f"Waiting on \"{' '.join(command)}\" to finish.", end='')
+#         time.sleep(1.0)
+#         while process.poll() is None:
+#             msg.logos_progress()
+#             time.sleep(0.5)
+#         print()
 
-        # Process has finished, check the result
-        stdout, stderr = process.communicate()
+#         # Process has finished, check the result
+#         stdout, stderr = process.communicate()
 
-        if process.returncode == 0:
-            logging.info(f"\"{' '.join(command)}\" has ended properly.")
-        else:
-            logging.error(f"Error: {stderr}")
+#         if process.returncode == 0:
+#             logging.info(f"\"{' '.join(command)}\" has ended properly.")
+#         else:
+#             logging.error(f"Error: {stderr}")
 
-    except Exception as e:
-        logging.critical(f"{e}")
+#     except Exception as e:
+#         logging.critical(f"{e}")
 
 
 def get_pids(query):
@@ -230,20 +230,20 @@ def get_logos_pids():
     config.processes[config.logos_indexer_exe] = get_pids(config.logos_indexer_exe)
 
 
-def get_pids_using_file(file_path, mode=None):
-    # Make list (set) of pids using 'directory'.
-    pids = set()
-    for proc in psutil.process_iter(['pid', 'open_files']):
-        try:
-            if mode is not None:
-                paths = [f.path for f in proc.open_files() if f.mode == mode]
-            else:
-                paths = [f.path for f in proc.open_files()]
-            if len(paths) > 0 and file_path in paths:
-                pids.add(proc.pid)
-        except psutil.AccessDenied:
-            pass
-    return pids
+# def get_pids_using_file(file_path, mode=None):
+#     # Make list (set) of pids using 'directory'.
+#     pids = set()
+#     for proc in psutil.process_iter(['pid', 'open_files']):
+#         try:
+#             if mode is not None:
+#                 paths = [f.path for f in proc.open_files() if f.mode == mode]
+#             else:
+#                 paths = [f.path for f in proc.open_files()]
+#             if len(paths) > 0 and file_path in paths:
+#                 pids.add(proc.pid)
+#         except psutil.AccessDenied:
+#             pass
+#     return pids
 
 
 def reboot():

--- a/tui_app.py
+++ b/tui_app.py
@@ -618,7 +618,7 @@ class TUI:
         config.WINE_EXE = choice
         if choice:
             self.menu_screen.choice = "Processing"
-            self.wine_q.put(config.WINE_EXE)
+            self.wines_q.put(config.WINE_EXE)
             self.wine_e.set()
 
     def winetricksbin_select(self, choice):

--- a/tui_app.py
+++ b/tui_app.py
@@ -68,7 +68,7 @@ class TUI:
         self.installdeps_e = threading.Event()
         self.installdir_q = Queue()
         self.installdir_e = threading.Event()
-        self.wine_q = Queue()
+        self.wines_q = Queue()
         self.wine_e = threading.Event()
         self.tricksbin_q = Queue()
         self.tricksbin_e = threading.Event()
@@ -362,7 +362,7 @@ class TUI:
             utils.start_thread(self.get_wine, config.use_python_dialog)
         elif task == 'WINETRICKSBIN':
             utils.start_thread(self.get_winetricksbin, config.use_python_dialog)
-        elif task == 'INSTALLING':
+        elif task == 'INSTALL' or task == 'INSTALLING':
             utils.start_thread(self.get_waiting, config.use_python_dialog)
         elif task == 'INSTALLING_PW':
             utils.start_thread(self.get_waiting, config.use_python_dialog, screen_id=15)
@@ -754,10 +754,7 @@ class TUI:
         utils.start_thread(network.get_logos_releases, daemon_bool=True, app=self)
         self.releases_e.wait()
 
-        if config.TARGETVERSION == '10':
-            labels = self.releases_q.get()
-        elif config.TARGETVERSION == '9':
-            labels = self.releases_q.get()
+        labels = self.releases_q.get()
 
         if labels is None:
             msg.logos_error("Failed to fetch TARGET_RELEASE_VERSION.")
@@ -787,7 +784,7 @@ class TUI:
 
     def get_wine(self, dialog):
         self.installdir_e.wait()
-        self.screen_q.put(self.stack_text(10, self.wine_q, self.wine_e, "Waiting to acquire available Wine binaries…", wait=True, dialog=dialog))
+        self.screen_q.put(self.stack_text(10, self.wines_q, self.wine_e, "Waiting to acquire available Wine binaries…", wait=True, dialog=dialog))
         question = f"Which Wine AppImage or binary should the script use to install {config.FLPRODUCT} v{config.TARGET_RELEASE_VERSION} in {config.INSTALLDIR}?"  # noqa: E501
         labels = utils.get_wine_options(
             utils.find_appimage_files(config.TARGET_RELEASE_VERSION),
@@ -798,10 +795,10 @@ class TUI:
         max_length += len(str(len(labels))) + 10
         options = self.which_dialog_options(labels, dialog)
         self.menu_options = options
-        self.screen_q.put(self.stack_menu(6, self.wine_q, self.wine_e, question, options, width=max_length, dialog=dialog))
+        self.screen_q.put(self.stack_menu(6, self.wines_q, self.wine_e, question, options, width=max_length, dialog=dialog))
 
     def set_wine(self, choice):
-        self.wine_q.put(utils.get_relative_path(utils.get_config_var(choice), config.INSTALLDIR))
+        self.wines_q.put(utils.get_relative_path(utils.get_config_var(choice), config.INSTALLDIR))
         self.menu_screen.choice = "Processing"
         self.wine_e.set()
 

--- a/utils.py
+++ b/utils.py
@@ -449,31 +449,46 @@ def get_winetricks_options():
     return winetricks_options
 
 
-def get_pids_using_file(file_path, mode=None):
-    pids = set()
-    for proc in psutil.process_iter(['pid', 'open_files']):
+def get_procs_using_file(file_path, mode=None):
+    procs = set()
+    for proc in psutil.process_iter(['pid', 'open_files', 'name']):
         try:
             if mode is not None:
                 paths = [f.path for f in proc.open_files() if f.mode == mode]
             else:
                 paths = [f.path for f in proc.open_files()]
             if len(paths) > 0 and file_path in paths:
-                pids.add(proc.pid)
+                procs.add(proc.pid)
         except psutil.AccessDenied:
             pass
-    return pids
+    return procs
 
 
-def wait_process_using_dir(directory):
-    logging.info(f"* Starting wait_process_using_dir for {directory}…")
+# def get_pids_using_file(file_path, mode=None):
+#     pids = set()
+#     for proc in psutil.process_iter(['pid', 'open_files']):
+#         try:
+#             if mode is not None:
+#                 paths = [f.path for f in proc.open_files() if f.mode == mode]
+#             else:
+#                 paths = [f.path for f in proc.open_files()]
+#             if len(paths) > 0 and file_path in paths:
+#                 pids.add(proc.pid)
+#         except psutil.AccessDenied:
+#             pass
+#     return pids
 
-    # Get pids and wait for them to finish.
-    pids = get_pids_using_file(directory)
-    for pid in pids:
-        logging.info(f"wait_process_using_dir PID: {pid}")
-        psutil.wait(pid)
 
-    logging.info("* End of wait_process_using_dir.")
+# def wait_process_using_dir(directory):
+#     logging.info(f"* Starting wait_process_using_dir for {directory}…")
+
+#     # Get pids and wait for them to finish.
+#     pids = get_pids_using_file(directory)
+#     for pid in pids:
+#         logging.info(f"wait_process_using_dir PID: {pid}")
+#         psutil.wait(pid)
+
+#     logging.info("* End of wait_process_using_dir.")
 
 
 def write_progress_bar(percent, screen_width=80):

--- a/utils.py
+++ b/utils.py
@@ -243,6 +243,7 @@ def check_dependencies(app=None):
 
     if app:
         if config.DIALOG == "tk":
+            # FIXME: This should get moved to gui_app.
             app.root.event_generate('<<StopIndeterminateProgress>>')
 
 

--- a/utils.py
+++ b/utils.py
@@ -425,8 +425,10 @@ def get_wine_options(appimages, binaries, app=None) -> Union[List[List[str]], Li
 
     logging.debug(f"{wine_binary_options=}")
     if app:
-        app.wines_q.put(wine_binary_options)
-        app.root.event_generate(app.wine_evt)
+        if config.DIALOG != "cli":
+            app.wines_q.put(wine_binary_options)
+            if config.DIALOG == 'tk':
+                app.root.event_generate(app.wine_evt)
     return wine_binary_options
 
 

--- a/wine.py
+++ b/wine.py
@@ -59,14 +59,15 @@ def wineserver_wait():
         process.wait()
 
 
-def light_wineserver_wait():
-    command = [f"{config.WINESERVER_EXE}", "-w"]
-    system.wait_on(command)
+# def light_wineserver_wait():
+#     command = [f"{config.WINESERVER_EXE}", "-w"]
+#     system.wait_on(command)
 
 
-def heavy_wineserver_wait():
-    utils.wait_process_using_dir(config.WINEPREFIX)
-    system.wait_on([f"{config.WINESERVER_EXE}", "-w"])
+# def heavy_wineserver_wait():
+#     utils.wait_process_using_dir(config.WINEPREFIX)
+#     # system.wait_on([f"{config.WINESERVER_EXE}", "-w"])
+#     wineserver_wait()
 
 
 def end_wine_processes():
@@ -215,7 +216,8 @@ def wine_reg_install(reg_file):
         msg.logos_error(f"{failed}: {reg_file}")
     elif process.returncode == 0:
         logging.info(f"{reg_file} installed.")
-    light_wineserver_wait()
+    # light_wineserver_wait()
+    wineserver_wait()
 
 
 def install_msi(app=None):
@@ -313,7 +315,13 @@ def run_winetricks_cmd(*args):
     process = run_wine_proc(config.WINETRICKSBIN, exe_args=cmd)
     wait_pid(process)
     logging.info(f"\"winetricks {' '.join(cmd)}\" DONE!")
-    heavy_wineserver_wait()
+    # heavy_wineserver_wait()
+    wineserver_wait()
+    logging.debug(f"procs using {config.WINEPREFIX}:")
+    for proc in utils.get_procs_using_file(config.WINEPREFIX):
+        logging.debug(f"{proc=}")
+    else:
+        logging.debug('<None>')
 
 
 def install_d3d_compiler():

--- a/wine.py
+++ b/wine.py
@@ -19,6 +19,9 @@ def set_logos_paths():
     config.login_window_cmd = f'C:\\users\\{config.wine_user}\\AppData\\Local\\Logos\\System\\Logos.exe'  # noqa: E501
     config.logos_cef_cmd = f'C:\\users\\{config.wine_user}\\AppData\\Local\\Logos\\System\\LogosCEF.exe'  # noqa: E501
     config.logos_indexing_cmd = f'C:\\users\\{config.wine_user}\\AppData\\Local\\Logos\\System\\LogosIndexer.exe'  # noqa: E501
+    # TODO: Can't this just be set based on WINEPREFIX and USER vars without
+    # having to walk through the WINEPREFIX tree? Or maybe this is to account
+    # for a non-typical installation location?
     for root, dirs, files in os.walk(os.path.join(config.WINEPREFIX, "drive_c")):  # noqa: E501
         for f in files:
             if f == "LogosIndexer.exe" and root.endswith("Logos/System"):


### PR DESCRIPTION
Fixes #128. Requires #158.

I should clarify my aim is to get it working and to make it pretty later (cf. #172).

Part of my goal in this PR is to make #147 potentially easier. The CLI is intentionally aiming to be a highly simplified event/queue manager, thus I aim to clear the event's status frequently in order to reuse it later. The TUI is, to my knowledge, never waiting on more than one event at a time. Therefore we have not need to have multiple events. If we do have some place where we are waiting on multiple, then we can have two different ones at that time. This would make the code much simpler, leaner, and easier to reuse.

What I imagine therefore, from this PR, is extracting all the event/queue code from the TUI, the CLI, and the GUI, into its own class module.