### PR TITLE
Add Dockerfile for building with Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+
+FROM ubuntu:focal
+
+# Prevent popups during install of requirements
+ENV DEBIAN_FRONTEND=noninteractive
+
+# LogosLinuxInstaller Requirements
+RUN apt update -qq && apt install -y -qq git build-essential gdb lcov pkg-config \
+    libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev \
+    libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev \
+    lzma lzma-dev python3-tk tk-dev uuid-dev zlib1g-dev && rm -rf /var/lib/apt/lists/*
+
+# pyenv for guaranteed py 3.12
+ENV HOME="/root"
+WORKDIR ${HOME}
+RUN apt update && apt install -y curl && rm -rf /var/lib/apt/lists/*
+RUN curl https://pyenv.run | bash
+ENV PYENV_ROOT="${HOME}/.pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:${PATH}"
+
+# Ensure tkinter
+ENV PYTHON_CONFIGURE_OPTS "--enable-shared"
+
+# install py 3.12
+ENV PYTHON_VERSION=3.12.6
+RUN pyenv install --verbose ${PYTHON_VERSION}
+RUN pyenv global ${PYTHON_VERSION}
+
+WORKDIR /usr/src/app
+ENTRYPOINT ["sh", "-c", "pip install --no-cache-dir pyinstaller -r requirements.txt && pyinstaller LogosLinuxInstaller.spec"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ $ cd LogosLinuxInstaller
 # docker run --rm -v $(pwd):/usr/src/app logosinstaller
 ```
 
+The built binary will now be in `./dist/LogosLinuxInstaller`.
+
 ## Install guide (possibly outdated)
 
 NOTE: You can run Logos on Linux using the Steam Proton Experimental binary, which often has the latest and greatest updates to make Logos run even smoother. The script should be able to find the binary automatically, unless your Steam install is located outside of your HOME directory.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Python 3.12.5
 (env) LogosLinuxInstaller$ ./main.py --help # run the script
 ```
 
+### Building using docker
+
+```
+$ git clone 'https://github.com/FaithLife-Community/LogosLinuxInstaller.git'
+$ cd LogosLinuxInstaller
+# docker build -t logosinstaller .
+# docker run --rm -v $(pwd):/usr/src/app logosinstaller
+```
+
 ## Install guide (possibly outdated)
 
 NOTE: You can run Logos on Linux using the Steam Proton Experimental binary, which often has the latest and greatest updates to make Logos run even smoother. The script should be able to find the binary automatically, unless your Steam install is located outside of your HOME directory.


### PR DESCRIPTION
Instead of setting up Python 3.12 on the machine itself, this allows users to use Docker to generate the relevant Linux binaries.

Example output:

```
$ sudo docker run --rm -v $(pwd):/usr/src/app logosinstaller
Collecting pyinstaller
  Downloading pyinstaller-6.10.0-py3-none-manylinux2014_x86_64.whl.metadata (8.3 kB)
Collecting altgraph==0.17.4 (from -r requirements.txt (line 1))
  Downloading altgraph-0.17.4-py2.py3-none-any.whl.metadata (7.3 kB)
Collecting certifi==2023.11.17 (from -r requirements.txt (line 2))
  Downloading certifi-2023.11.17-py3-none-any.whl.metadata (2.2 kB)
Collecting charset-normalizer==3.3.2 (from -r requirements.txt (line 3))
  Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (33 kB)
Collecting distro==1.9.0 (from -r requirements.txt (line 4))
  Downloading distro-1.9.0-py3-none-any.whl.metadata (6.8 kB)
Collecting idna==3.6 (from -r requirements.txt (line 5))
  Downloading idna-3.6-py3-none-any.whl.metadata (9.9 kB)
Collecting packaging==23.2 (from -r requirements.txt (line 6))
  Downloading packaging-23.2-py3-none-any.whl.metadata (3.2 kB)
Collecting psutil==5.9.7 (from -r requirements.txt (line 7))
  Downloading psutil-5.9.7-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (21 kB)
Collecting pythondialog==3.5.3 (from -r requirements.txt (line 8))
  Downloading pythondialog-3.5.3-py3-none-any.whl.metadata (12 kB)
Collecting requests==2.31.0 (from -r requirements.txt (line 9))
  Downloading requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting urllib3==2.1.0 (from -r requirements.txt (line 10))
  Downloading urllib3-2.1.0-py3-none-any.whl.metadata (6.4 kB)
Collecting setuptools>=42.0.0 (from pyinstaller)
  Downloading setuptools-75.1.0-py3-none-any.whl.metadata (6.9 kB)
Collecting pyinstaller-hooks-contrib>=2024.8 (from pyinstaller)
  Downloading pyinstaller_hooks_contrib-2024.8-py3-none-any.whl.metadata (16 kB)
Downloading altgraph-0.17.4-py2.py3-none-any.whl (21 kB)
Downloading certifi-2023.11.17-py3-none-any.whl (162 kB)
Downloading charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (141 kB)
Downloading distro-1.9.0-py3-none-any.whl (20 kB)
Downloading idna-3.6-py3-none-any.whl (61 kB)
Downloading packaging-23.2-py3-none-any.whl (53 kB)
Downloading psutil-5.9.7-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (285 kB)
Downloading pythondialog-3.5.3-py3-none-any.whl (54 kB)
Downloading requests-2.31.0-py3-none-any.whl (62 kB)
Downloading urllib3-2.1.0-py3-none-any.whl (104 kB)
Downloading pyinstaller-6.10.0-py3-none-manylinux2014_x86_64.whl (703 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 703.3/703.3 kB 7.9 MB/s eta 0:00:00
Downloading pyinstaller_hooks_contrib-2024.8-py3-none-any.whl (322 kB)
Downloading setuptools-75.1.0-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 9.3 MB/s eta 0:00:00
Installing collected packages: altgraph, urllib3, setuptools, pythondialog, psutil, packaging, idna, distro, charset-normalizer, certifi, requests, pyinstaller-hooks-contrib, pyinstaller
Successfully installed altgraph-0.17.4 certifi-2023.11.17 charset-normalizer-3.3.2 distro-1.9.0 idna-3.6 packaging-23.2 psutil-5.9.7 pyinstaller-6.10.0 pyinstaller-hooks-contrib-2024.8 pythondialog-3.5.3 requests-2.31.0 setuptools-75.1.0 urllib3-2.1.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
90 INFO: PyInstaller: 6.10.0, contrib hooks: 2024.8
91 INFO: Python: 3.12.6
93 INFO: Platform: Linux-6.1.0-25-amd64-x86_64-with-glibc2.31
93 INFO: Python environment: /root/.pyenv/versions/3.12.6
95 INFO: Module search paths (PYTHONPATH):
['/root/.pyenv/versions/3.12.6/lib/python312.zip',
 '/root/.pyenv/versions/3.12.6/lib/python3.12',
 '/root/.pyenv/versions/3.12.6/lib/python3.12/lib-dynload',
 '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages',
 '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/setuptools/_vendor',
 '/usr/src/app']
218 INFO: Appending 'datas' from .spec
218 INFO: checking Analysis
240 INFO: Building because /root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks/pyi_rth_inspect.py changed
240 INFO: Running Analysis Analysis-00.toc
240 INFO: Target bytecode optimization level: 0
241 INFO: Initializing module dependency graph...
242 INFO: Caching module graph hooks...
262 INFO: Analyzing base_library.zip ...
1449 INFO: Processing standard module hook 'hook-encodings.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
2193 INFO: Processing standard module hook 'hook-heapq.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
3526 INFO: Processing standard module hook 'hook-pickle.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
5542 INFO: Caching module dependency graph...
5654 INFO: Looking for Python shared library...
5664 INFO: Using Python shared library: /root/.pyenv/versions/3.12.6/lib/libpython3.12.so.1.0
5664 INFO: Analyzing /usr/src/app/main.py
6199 INFO: Processing standard module hook 'hook-_tkinter.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
6400 INFO: Processing standard module hook 'hook-psutil.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/_pyinstaller_hooks_contrib/stdhooks'
6583 INFO: Processing standard module hook 'hook-platform.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
6720 INFO: Processing pre-safe-import-module hook 'hook-packaging.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
6721 INFO: SetuptoolsInfo: initializing cached setuptools info...
12228 INFO: Processing standard module hook 'hook-packaging.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
12859 INFO: Processing pre-safe-import-module hook 'hook-typing_extensions.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
13101 INFO: Processing standard module hook 'hook-charset_normalizer.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/_pyinstaller_hooks_contrib/stdhooks'
13595 INFO: Processing standard module hook 'hook-certifi.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/_pyinstaller_hooks_contrib/stdhooks'
13831 INFO: Processing standard module hook 'hook-xml.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
13865 INFO: Processing standard module hook 'hook-xml.etree.cElementTree.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/dialog.py:3648: SyntaxWarning: invalid escape sequence '\s'
  """Display a treeview box.
14390 INFO: Processing module hooks (post-graph stage)...
14552 INFO: Processing standard module hook 'hook-pkg_resources.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
15012 INFO: Processing standard module hook 'hook-sysconfig.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
15049 INFO: Processing pre-safe-import-module hook 'hook-jaraco.text.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15049 INFO: Setuptools: 'jaraco.text' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.jaraco.text'!
15058 INFO: Processing standard module hook 'hook-setuptools.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
15075 INFO: Processing pre-safe-import-module hook 'hook-distutils.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15109 INFO: Processing pre-safe-import-module hook 'hook-jaraco.functools.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15109 INFO: Setuptools: 'jaraco.functools' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.jaraco.functools'!
15174 INFO: Processing pre-safe-import-module hook 'hook-more_itertools.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15175 INFO: Setuptools: 'more_itertools' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.more_itertools'!
15534 INFO: Processing pre-safe-import-module hook 'hook-importlib_metadata.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15534 INFO: Setuptools: 'importlib_metadata' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.importlib_metadata'!
15578 INFO: Processing pre-safe-import-module hook 'hook-zipp.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15578 INFO: Setuptools: 'zipp' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.zipp'!
15626 INFO: Processing pre-safe-import-module hook 'hook-importlib_resources.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
15627 INFO: Setuptools: 'importlib_resources' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.importlib_resources'!
16039 INFO: Processing pre-safe-import-module hook 'hook-tomli.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
16039 INFO: Setuptools: 'tomli' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.tomli'!
16758 INFO: Processing pre-safe-import-module hook 'hook-wheel.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
16758 INFO: Setuptools: 'wheel' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.wheel'!
17029 INFO: Processing pre-safe-import-module hook 'hook-jaraco.context.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
17029 INFO: Setuptools: 'jaraco.context' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.jaraco.context'!
17040 INFO: Processing pre-safe-import-module hook 'hook-backports.tarfile.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
17041 INFO: Setuptools: 'backports.tarfile' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.backports.tarfile'!
17175 INFO: Processing standard module hook 'hook-backports.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/_pyinstaller_hooks_contrib/stdhooks'
17176 INFO: Processing pre-safe-import-module hook 'hook-platformdirs.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
17177 INFO: Setuptools: 'platformdirs' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.platformdirs'!
17282 INFO: Processing standard module hook 'hook-_tkinter.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
17282 INFO: TclTkInfo: initializing cached Tcl/Tk info...
17348 WARNING: TclTkInfo: Tcl module directory '/usr/share/tcltk/tcl8' does not exist!
18002 INFO: Processing standard module hook 'hook-multiprocessing.util.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks'
18629 INFO: Processing pre-safe-import-module hook 'hook-autocommand.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
18629 INFO: Setuptools: 'autocommand' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.autocommand'!
19357 INFO: Processing pre-safe-import-module hook 'hook-typeguard.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/pre_safe_import_module'
19358 INFO: Setuptools: 'typeguard' appears to be a setuptools-vendored copy - creating alias to 'setuptools._vendor.typeguard'!
19895 INFO: Performing binary vs. data reclassification (429 entries)
19912 INFO: Looking for ctypes DLLs
20005 INFO: Analyzing run-time hooks ...
20010 INFO: Including run-time hook 'pyi_rth_inspect.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20012 INFO: Including run-time hook 'pyi_rth_pkgres.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20018 INFO: Including run-time hook 'pyi_rth_setuptools.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20020 INFO: Including run-time hook 'pyi_rth_multiprocessing.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20022 INFO: Including run-time hook 'pyi_rth_pkgutil.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20024 INFO: Including run-time hook 'pyi_rth__tkinter.py' from '/root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/hooks/rthooks'
20055 INFO: Looking for dynamic libraries
20608 INFO: Warnings written to /usr/src/app/build/LogosLinuxInstaller/warn-LogosLinuxInstaller.txt
20672 INFO: Graph cross-reference written to /usr/src/app/build/LogosLinuxInstaller/xref-LogosLinuxInstaller.html
20706 INFO: checking PYZ
20712 INFO: Building because /root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/_distutils_hack/__init__.py changed
20712 INFO: Building PYZ (ZlibArchive) /usr/src/app/build/LogosLinuxInstaller/PYZ-00.pyz
21401 INFO: Building PYZ (ZlibArchive) /usr/src/app/build/LogosLinuxInstaller/PYZ-00.pyz completed successfully.
21439 INFO: checking PKG
21444 INFO: Building because toc changed
21444 INFO: Building PKG (CArchive) LogosLinuxInstaller.pkg
36563 INFO: Building PKG (CArchive) LogosLinuxInstaller.pkg completed successfully.
36588 INFO: Bootloader /root/.pyenv/versions/3.12.6/lib/python3.12/site-packages/PyInstaller/bootloader/Linux-64bit-intel/run
36589 INFO: checking EXE
36598 INFO: Building because toc changed
36598 INFO: Building EXE from EXE-00.toc
36609 INFO: Copying bootloader EXE to /usr/src/app/dist/LogosLinuxInstaller
36610 INFO: Appending PKG archive to custom ELF section in EXE
36749 INFO: Building EXE from EXE-00.toc completed successfully.
```

What has not been assumed has not been healed 
– St. Gregory of Nazianzus