### PR TITLE
docs: update README with new invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ LogosLinuxInstaller$ source env/bin/activate # activate the env
 Python 3.12.5
 (env) LogosLinuxInstaller$ python -m tkinter # verify that tkinter test window opens
 (env) LogosLinuxInstaller$ pip install -r requirements.txt # install python packages
-(env) LogosLinuxInstaller$ ./main.py --help # run the script
+(env) LogosLinuxInstaller$ python -m ou_dedetai.main --help # run the script
 ```
 
 ### Building using docker


### PR DESCRIPTION
There is no ./main.py anymore. Perhaps we should re-word this documentation to use the pypi package instead