### PR TITLE
fix: install dependencies on the cli

### DIFF
--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -40,7 +40,7 @@ class CLI:
         wine.install_d3d_compiler()
 
     def install_dependencies(self):
-        utils.check_dependencies()
+        utils.check_dependencies(app=self)
 
     def install_fonts(self):
         wine.install_fonts()


### PR DESCRIPTION
Packages are only checked if app is not None https://github.com/FaithLife-Community/LogosLinuxInstaller/blob/0def2e5b99225db5de97fea97acaaaa0d8efa52b/ou_dedetai/system.py#L421