### PR TITLE
fix: always install passively

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -98,7 +98,6 @@ PACKAGE_MANAGER_COMMAND_INSTALL: Optional[list[str]] = None
 PACKAGE_MANAGER_COMMAND_REMOVE: Optional[list[str]] = None
 PACKAGE_MANAGER_COMMAND_QUERY: Optional[list[str]] = None
 PACKAGES: Optional[str] = None
-PASSIVE: Optional[bool] = None
 pid_file = f'/tmp/{name_binary}.pid'
 PRESENT_WORKING_DIRECTORY: str = os.getcwd()
 QUERY_PREFIX: Optional[str] = None

--- a/ou_dedetai/main.py
+++ b/ou_dedetai/main.py
@@ -83,10 +83,6 @@ def get_parser():
         '-L', '--delete-log', action='store_true',
         help='delete the log file',
     )
-    cfg.add_argument(
-        '-P', '--passive', action='store_true',
-        help='run product installer non-interactively',
-    )
 
     # Define runtime actions (mutually exclusive).
     grp = parser.add_argument_group(
@@ -238,9 +234,6 @@ def parse_args(args, parser):
         else:
             message = f"Custom binary path does not exist: \"{args.custom_binary_path}\"\n"  # noqa: E501
             parser.exit(status=1, message=message)
-
-    if args.passive:
-        config.PASSIVE = True
 
     # Set ACTION function.
     actions = {

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -286,9 +286,7 @@ def install_msi(app=None):
     msg.status(f"Running MSI installer: {config.LOGOS_EXECUTABLE}.", app)
     # Execute the .MSI
     wine_exe = str(utils.get_wine_exe_path().parent / 'wine64')
-    exe_args = ["/i", f"{config.INSTALLDIR}/data/{config.LOGOS_EXECUTABLE}"]
-    if config.PASSIVE is True:
-        exe_args.append('/passive')
+    exe_args = ["/i", f"{config.INSTALLDIR}/data/{config.LOGOS_EXECUTABLE}", "/passive"]
     logging.info(f"Running: {wine_exe} msiexec {' '.join(exe_args)}")
     process = run_wine_proc(wine_exe, exe="msiexec", exe_args=exe_args)
     return process


### PR DESCRIPTION
For some reason non-passive installs were failing

As a user I see no need to hit a single next button on a dialog I've already given my consent to install by installing our installer

Tested working with icu 72.1-custom+4