### PR TITLE
fix: add required fuse package to fedora

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -334,7 +334,7 @@ def get_package_manager():
         config.QUERY_PREFIX = ''
         # config.PACKAGES = "patch fuse3 fuse3-libs mod_auth_ntlm_winbind samba-winbind samba-winbind-clients cabextract bc libxml2 curl"  # noqa: E501
         config.PACKAGES = (
-            "fuse3 fuse3-libs "  # appimages
+            "fuse3 fuse3-libs fuse"  # appimages
             "mod_auth_ntlm_winbind samba-winbind samba-winbind-clients cabextract "  # wine  # noqa: E501
             "p7zip-plugins "  # winetricks
         )


### PR DESCRIPTION
"fuse" package needed for fusermount
"fuse3" package provides fusermount3

When the fuse package isn't installed:
```
$ ./oudedetai --install-app
...
Installing registry file: /tmp/LBS.2r05magl/disable-winemenubuilder.reg
2024-11-14 14:57:56 ERROR: Error occurred in run_command() while executing "['/home/user/LogosBible10/data/bin/wine64', 'reg', 'query', 'HKCU\\Software\\Wine\\Fonts', '/v', 'Codepages']": Command '['/home/user/LogosBible10/data/bin/wine64', 'reg', 'query', 'HKCU\\Software\\Wine\\Fonts', '/v', 'Codepages']' returned non-zero exit status 127.
2024-11-14 14:57:56 WARNING: Failed to get registry value: HKCU\Software\Wine\Fonts\Codepages
2024-11-14 14:57:56 ERROR: wine.wine_proc: wine.get_registry_value returned None.
Failed to install reg file: /tmp/LBS.2r05magl/disable-winemenubuilder.reg
2024-11-14 14:57:56 CRITICAL: Failed to install reg file: /tmp/LBS.2r05magl/disable-winemenubuilder.reg
Killed
$ /home/user/LogosBible10/data/bin/wine64 reg query HKCU\\Software\\Wine\\Fonts /v Codepages
fuse: failed to exec fusermount: No such file or directory

Cannot mount AppImage, please check your FUSE setup.
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
open dir error: No such file or directory
```

This using Fedora-40