### PR TITLE
fix: ensure local desktop file directory exists

### DIFF
--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -777,7 +777,7 @@ def create_desktop_file(name, contents):
         logging.info(f"Removing desktop launcher at {launcher_path}.")
         launcher_path.unlink()
     # Ensure the parent directory exists
-    launcher_path.parent.mkdir(parents=True)
+    launcher_path.parent.mkdir(parents=True, exist_ok=True)
 
     logging.info(f"Creating desktop launcher at {launcher_path}.")
     with launcher_path.open('w') as f:

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -776,6 +776,8 @@ def create_desktop_file(name, contents):
     if launcher_path.is_file():
         logging.info(f"Removing desktop launcher at {launcher_path}.")
         launcher_path.unlink()
+    # Ensure the parent directory exists
+    launcher_path.parent.mkdir(parents=True)
 
     logging.info(f"Creating desktop launcher at {launcher_path}.")
     with launcher_path.open('w') as f:


### PR DESCRIPTION
Workaround:
```
mkdir -p ~/.local/share/applications
```

Fixes: #230