### PR TITLE
make dependencies lists more precise

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -334,9 +334,15 @@ def get_package_manager():
         # NOTE: Package names changed together for Ubuntu 24+, Debian 13+, and
         # derivatives. This does not include an exhaustive list of distros that
         # use 'apt', so others will have to be added as users report issues.
+        # Ref:
+        # - https://askubuntu.com/a/445496
+        # - https://en.wikipedia.org/wiki/Linux_Mint
+        # - https://en.wikipedia.org/wiki/Elementary_OS
+        # - https://github.com/which-distro/os-release/tree/main
         if (
-            (config.OS_NAME == 'ubuntu' and major_ver >= '24')
-            or (config.OS_NAME == 'debian' and major_ver >= '13')
+            (config.OS_NAME == 'debian' and major_ver >= '13')
+            or (config.OS_NAME == 'ubuntu' and major_ver >= '24')
+            or (config.OS_NAME == 'linuxmint' and major_ver >= '22')
             or (config.OS_NAME == 'elementary' and major_ver >= '8')
         ):
             config.PACKAGES = (
@@ -371,7 +377,7 @@ def get_package_manager():
             "fuse2 "  # appimages
             "samba wget "  # wine
             "7zip "  # winetricks
-            "curl gawk grep patch "  # other
+            "curl gawk grep "  # other
         )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
         config.BADPACKAGES = ""  # appimagelauncher handled separately
@@ -385,7 +391,7 @@ def get_package_manager():
             "fuse2 "  # appimages
             "samba wget "  # wine
             "p7zip "  # winetricks
-            "bc curl gawk grep libxml2 patch "  # other
+            "curl gawk grep "  # other
         )
         config.L9PACKAGES = ""  # FIXME: Missing Logos 9 Packages
         config.BADPACKAGES = ""  # appimagelauncher handled separately

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -355,7 +355,7 @@ def get_package_manager():
         config.QUERY_PREFIX = ''
         # config.PACKAGES = "patch fuse3 fuse3-libs mod_auth_ntlm_winbind samba-winbind samba-winbind-clients cabextract bc libxml2 curl"  # noqa: E501
         config.PACKAGES = (
-            "fuse-libs "  # appimages
+            "fuse fuse-libs "  # appimages
             "mod_auth_ntlm_winbind samba-winbind samba-winbind-clients "  # wine  # noqa: E501
             "p7zip-plugins "  # winetricks
         )

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -260,14 +260,6 @@ def reboot():
     sys.exit(0)
 
 
-def tl(library):
-    try:
-        __import__(library)
-        return True
-    except ImportError:
-        return False
-
-
 def get_dialog():
     if not os.environ.get('DISPLAY'):
         msg.logos_error("The installer does not work unless you are running a display")  # noqa: E501

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -184,35 +184,6 @@ def popen_command(command, retries=1, delay=0, **kwargs):
     return None
 
 
-# def wait_on(command):
-#     try:
-#         # Start the process in the background
-#         # TODO: Convert to use popen_command()
-#         process = subprocess.Popen(
-#             command,
-#             stdout=subprocess.PIPE,
-#             stderr=subprocess.PIPE,
-#             text=True
-#         )
-#         msg.status(f"Waiting on \"{' '.join(command)}\" to finish.", end='')
-#         time.sleep(1.0)
-#         while process.poll() is None:
-#             msg.logos_progress()
-#             time.sleep(0.5)
-#         print()
-
-#         # Process has finished, check the result
-#         stdout, stderr = process.communicate()
-
-#         if process.returncode == 0:
-#             logging.info(f"\"{' '.join(command)}\" has ended properly.")
-#         else:
-#             logging.error(f"Error: {stderr}")
-
-#     except Exception as e:
-#         logging.critical(f"{e}")
-
-
 def get_pids(query):
     results = []
     for process in psutil.process_iter(['pid', 'name', 'cmdline']):
@@ -229,22 +200,6 @@ def get_logos_pids():
     config.processes[config.logos_login_cmd] = get_pids(config.logos_login_cmd)
     config.processes[config.logos_cef_cmd] = get_pids(config.logos_cef_cmd)
     config.processes[config.logos_indexer_exe] = get_pids(config.logos_indexer_exe)  # noqa: E501
-
-
-# def get_pids_using_file(file_path, mode=None):
-#     # Make list (set) of pids using 'directory'.
-#     pids = set()
-#     for proc in psutil.process_iter(['pid', 'open_files']):
-#         try:
-#             if mode is not None:
-#                 paths = [f.path for f in proc.open_files() if f.mode == mode]
-#             else:
-#                 paths = [f.path for f in proc.open_files()]
-#             if len(paths) > 0 and file_path in paths:
-#                 pids.add(proc.pid)
-#         except psutil.AccessDenied:
-#             pass
-#     return pids
 
 
 def reboot():
@@ -686,19 +641,6 @@ def install_dependencies(packages, bad_packages, logos9_packages=None, app=None)
 
         preinstall_command = preinstall_dependencies()
 
-        # TODO: Remove the code below when it's confirmed that libfuse is
-        # properly handled in get_package_manager().
-        # # libfuse: for AppImage use. This is the only known needed library.
-        # if config.OS_NAME == "fedora":
-        #     fuse = "fuse"
-        # else:
-        #     fuse = "libfuse"
-
-        # fuse_lib_installed = check_libs([f"{fuse}"], app=app)
-        # logging.debug(f"{fuse_lib_installed=}")
-        # # if not fuse_lib_installed:
-        # #     missing_packages.append(fuse)
-
         if missing_packages:
             install_command = config.PACKAGE_MANAGER_COMMAND_INSTALL + missing_packages  # noqa: E501
         else:
@@ -817,40 +759,6 @@ def install_dependencies(packages, bad_packages, logos9_packages=None, app=None)
         if app:
             if config.DIALOG == "curses":
                 app.installdeps_e.set()
-
-# TODO: Remove the code below when it's confirmed that libfuse is
-# properly handled in get_package_manager().
-# def have_lib(library, ld_library_path):
-#     available_library_paths = ['/usr/lib', '/lib']
-#     if ld_library_path is not None:
-#         available_library_paths = [*ld_library_path.split(':'), *available_library_paths]  # noqa: E501
-
-#     roots = [root for root in available_library_paths if not Path(root).is_symlink()]  # noqa: E501
-#     logging.debug(f"Library Paths: {roots}")
-#     for root in roots:
-#         libs = []
-#         logging.debug(f"Have lib? Checking {root}")
-#         for lib in Path(root).rglob(f"{library}*"):
-#             logging.debug(f"DEV: {lib}")
-#             libs.append(lib)
-#             break
-#         if len(libs) > 0:
-#             logging.debug(f"'{library}' found at '{libs[0]}'")
-#             return True
-#     return False
-
-# TODO: Remove the code below when it's confirmed that libfuse is
-# properly handled in get_package_manager().
-# def check_libs(libraries, app=None):
-#     ld_library_path = os.environ.get('LD_LIBRARY_PATH')
-#     for library in libraries:
-#         have_lib_result = have_lib(library, ld_library_path)
-#         if have_lib_result:
-#             logging.info(f"* {library} is installed!")
-#             return True
-#         else:
-#             logging.info(f"* {library} is not installed!")
-#             return False
 
 
 def install_winetricks(

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -340,7 +340,7 @@ def get_package_manager():
             or (config.OS_NAME == 'elementary' and major_ver >= '8')
         ):
             config.PACKAGES = (
-                "libfuse2t64 "  # appimages
+                "libfuse3-3 "  # appimages
                 "binutils wget winbind "  # wine
                 "7zip "  # winetricks
             )

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -317,8 +317,8 @@ def get_package_manager():
     major_ver = distro.major_version()
     logging.debug(f"{config.OS_NAME=}; {major_ver=}")
     # Check for package manager and associated packages.
-    # NOTE: cabextract and sed are included in the appimage, so they have been
-    # removed from the dependencies lists.
+    # NOTE: cabextract and sed are included in the appimage, so they are not
+    # included as system dependencies.
     if shutil.which('apt') is not None:  # debian, ubuntu, & derivatives
         config.PACKAGE_MANAGER_COMMAND_INSTALL = ["apt", "install", "-y"]
         config.PACKAGE_MANAGER_COMMAND_DOWNLOAD = ["apt", "install", "--download-only", "-y"]  # noqa: E501
@@ -356,7 +356,13 @@ def get_package_manager():
         config.PACKAGE_MANAGER_COMMAND_INSTALL = ["dnf", "install", "-y"]
         config.PACKAGE_MANAGER_COMMAND_DOWNLOAD = ["dnf", "install", "--downloadonly", "-y"]  # noqa: E501
         config.PACKAGE_MANAGER_COMMAND_REMOVE = ["dnf", "remove", "-y"]
+        # Fedora < 41 uses dnf4, while Fedora  41 uses dnf5. The dnf list
+        # command is sligtly different between the two.
+        # https://discussion.fedoraproject.org/t/after-f41-upgrade-dnf-says-no-packages-are-installed/135391  # noqa: E501
+        # Fedora < 41
         # config.PACKAGE_MANAGER_COMMAND_QUERY = ["dnf", "list", "installed"]
+        # Fedora 41
+        # config.PACKAGE_MANAGER_COMMAND_QUERY = ["dnf", "list", "--installed"]
         config.PACKAGE_MANAGER_COMMAND_QUERY = ["rpm", "-qa"]  # workaround
         config.QUERY_PREFIX = ''
         # config.PACKAGES = "patch fuse3 fuse3-libs mod_auth_ntlm_winbind samba-winbind samba-winbind-clients cabextract bc libxml2 curl"  # noqa: E501

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -442,7 +442,7 @@ def get_winetricks_options():
         # Check if local winetricks version is up-to-date.
         cmd = ["winetricks", "--version"]
         local_winetricks_version = subprocess.check_output(cmd).split()[0]
-        if str(local_winetricks_version) != config.WINETRICKS_VERSION: #noqa: E501
+        if str(local_winetricks_version) != config.WINETRICKS_VERSION:
             winetricks_options.insert(0, local_winetricks_path)
         else:
             logging.info("Local winetricks is too old.")

--- a/scripts/distro-info.sh
+++ b/scripts/distro-info.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Creates a text file at ~/distro-info.log with output from python's distro
+# module and from various known text files that give distro details. This is
+# is intended to cover as many Linux distributions as possible.
+
+# Initialize log file.
+logfile=~/distro-info.log
+date --utc > "$logfile"
+echo >> "$logfile"
+
+# Determine python executable.
+python=python
+if which python3 >/dev/null; then
+    python=python3
+fi
+
+# Record python's distro output.
+if which $python >/dev/null && $python -c 'import distro' 2>/dev/null; then
+    $python -c 'import distro; print(f"{distro.info()=}")' >> "$logfile"
+    $python -c 'import distro; print(f"{distro.os_release_info()=}")' >> "$logfile"
+    $python -c 'import distro; print(f"{distro.lsb_release_info()=}")' >> "$logfile"
+    $python -c 'import distro; print(f"{distro.distro_release_info()=}")' >> "$logfile"
+    $python -c 'import distro; print(f"{distro.uname_info()=}")' >> "$logfile"
+    echo >> "$logfile"
+fi
+
+# As a fallback, gather [mostly] the same info that python.distro gathers.
+# Ref: https://distro.readthedocs.io/en/latest/#data-sources
+if [ -r /etc/os-release ]; then
+    echo /etc/os-release >> "$logfile"
+    cat /etc/os-release >> "$logfile"
+    echo >> "$logfile"
+elif [ -r /usr/lib/os-release ]; then
+    echo /usr/lib/os-release >> "$logfile"
+    cat /usr/lib/os-release >> "$logfile"
+    echo >> "$logfile"
+fi
+
+if which lsb_release >/dev/null 2>&1; then
+    echo "lsb_release -a" >> "$logfile"
+    lsb_release -a >> "$logfile"
+    echo >> "$logfile"
+fi
+
+if which uname >/dev/null; then
+    echo "uname -rs" >> "$logfile"
+    uname -rs >> "$logfile"
+    echo >> "$logfile"
+fi


### PR DESCRIPTION
- fix #229
- update dependency package names for newer debian-based distros
- remove `cabextract` and `sed` dependencies b/c they're included in the wine appimage

I will test this in debian/ubuntu/fedora VMs before removing "draft" status. I trust others will test other distros as needed :wink:.

EDIT: Explicit requirements seem to be:
- `fusermount` command
- *some* kind of `libfuse*.so`, but must be compatible with the `fusermount` binary

This is complicated because Ubuntu symlinks `/bin/fusermount` to `/bin/fusermount3`, so it only needs the `fuse3` package, which provides both `fusermount` and brings in `libfuse3-3` as its own dependency, which is the library compatible with that `fusermount` (which is really`fusermount3`). But then other distros (e.g. fedora) keep fuse 2 and 3 completely separate, so in order to provide `fusermount`, fedora users must have `fuse` installed, which in turn *needs* `libfuse.so.2` provided by `fuse-libs` but is not an explicit dependency, so both `fuse` and `fuse-libs` are explicitly given in my changes below.