### PR TITLE
refactor: build python in a temporary directory

### DIFF
--- a/scripts/ensure-python.sh
+++ b/scripts/ensure-python.sh
@@ -19,11 +19,15 @@ fi
 # Warn about build deps.
 echo "Warning: You will likely need to install build dependencies for your system."
 echo "e.g. Debian 12 requires:"
-echo "build-essential gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev"
+echo "build-essential gdb lcov pkg-config libbz2-dev libffi-dev libgdbm-dev libgdbm-compat-dev liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev wget"
 read -r -p "Continue? [Y/n] " ans
 if [[ ${ans,,} != 'y' && $ans != '' ]]; then
     exit 1
 fi
+
+# Switch into a temporary directory
+TEMP_DIR=`mktemp -d`
+cd $TEMP_DIR
 
 # Download and build python3.12 from source.
 echo "Downloading $python_src..."
@@ -62,3 +66,6 @@ if [[ "$prefix" == '/opt' ]]; then
     echo "LD_LIBRARY_PATH=${prefix}/lib $python_exec_path"
 fi
 cd ~
+# This fails to remove some __pycache__ files that sudo make install generated.
+# No worries, they'll be removed next system reboot (as it's a temp folder)
+rm -rf $TEMP_DIR 2> /dev/null


### PR DESCRIPTION
it does fail to remove some pycache directories, hence why stderr is hidden
```
rm: cannot remove '/tmp/tmp.jOGMsQk7vC/Python-3.12.8/Lib/xml/parsers/__pycache__/__init__.cpython-312.pyc': Permission denied
rm: cannot remove '/tmp/tmp.jOGMsQk7vC/Python-3.12.8/Lib/xml/parsers/__pycache__/expat.cpython-312.pyc': Permission denied
```