### PR TITLE
fix: disable updates to logos 39, currently broken

### DIFF
--- a/ou_dedetai/network.py
+++ b/ou_dedetai/network.py
@@ -538,12 +538,10 @@ def get_logos_releases(app=None):
         # if len(releases) == 5:
         #    break
 
-    # Disabled filtering: with Logos 30+, all versions are known to be working.
-    # Keeping code if it needs to be reactivated.
-    # filtered_releases = utils.filter_versions(releases, 36, 1)
-    # logging.debug(f"Available releases: {', '.join(releases)}")
-    # logging.debug(f"Filtered releases: {', '.join(filtered_releases)}")
-    filtered_releases = releases
+    # Logos 39+ doesn't install
+    filtered_releases = utils.filter_versions(releases, 39, 1)
+    logging.debug(f"Available releases: {', '.join(releases)}")
+    logging.debug(f"Filtered releases: {', '.join(filtered_releases)}")
 
     if app:
         if config.DIALOG == 'tk':


### PR DESCRIPTION
An update to logos 39 breaks the install, as well as a fresh install fails