### PR TITLE
fix: appimage download issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,18 @@
 # Changelog
 
 - 4.0.0-beta.6
-  - Fix #234 [N. Shaaban]
-  - Fix #187 [N. Shaaban]
-  - Fix #168 [N. Shaaban]
-  - Fix #155 [N. Shaaban]
-  - Fix #147 [N. Shaaban]
-  - Fix #253 [N. Marti]
-  - Fix #252 [N. Marti]
+	- Fix #256 [J. Goodman]
+	- Fix #269 [T. H. Wright]
+	- Fix #234 [N. Shaaban]
+	- Fix #187 [N. Shaaban]
+	- Fix #168 [N. Shaaban]
+	- Fix #155 [N. Shaaban]
+	- Fix #147 [N. Shaaban]
+	- Fix #253 [N. Marti]
+	- Fix #252 [N. Marti]
 	- Implemented network cache [N. Shaaban]
 	- Refactored configuration handling (no user action required) [N. Shaaban]
-  - Fix #235 [T. H. Wright]
+  	- Fix #235 [T. H. Wright]
 - 4.0.0-beta.5
 	- Filter out broken Logos v39 release [N. Shaaban]
 	- Fix #17 [T. H. Wright]

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -86,7 +86,7 @@ def ensure_appimage_download(app: App):
     app.status("Ensuring wine AppImage is downloaded…")
 
     downloaded_file = None
-    appimage_path = app.conf.wine_appimage_path or app.conf.wine_appimage_recommended_file_name #noqa: E501
+    appimage_path = app.conf.wine_appimage_recommended_file_name #noqa: E501
     filename = Path(appimage_path).name
     downloaded_file = utils.get_downloaded_file_path(app.conf.download_dir, filename)
     if not downloaded_file:
@@ -293,7 +293,7 @@ def ensure_product_installed(app: App):
     app.conf._installed_faithlife_product_release = None
 
     # Clean up temp files, etc.
-    mst_destination = Path(app.conf.install_dir) / "data/wine64_bottle/drive_c/LogosStubFailOK.mst"
+    mst_destination = Path(app.conf.install_dir) / "data/wine64_bottle/drive_c/LogosStubFailOK.mst" #noqa E501
     if mst_destination and mst_destination.is_file():
         try:
             mst_destination.unlink()
@@ -374,9 +374,15 @@ def create_wine_appimage_symlinks(app: App):
     if app.conf.wine_binary_code not in ['AppImage', 'Recommended'] or app.conf.wine_appimage_path is None: #noqa: E501
         logging.debug("No need to symlink non-appimages")
         return
-
-    appimage_file = appdir_bindir / app.conf.wine_appimage_path.name
-    appimage_filename = Path(app.conf.wine_appimage_path).name
+    
+    # Only use the appimage_path if it exists
+    # It may not exist if it was an old install's .appimage
+    # where the install dir has been cleared.
+    if app.conf.wine_appimage_path.exists():
+        appimage_filename = app.conf.wine_appimage_path.name
+    else:
+        appimage_filename = app.conf.wine_appimage_recommended_file_name
+    appimage_file = appdir_bindir / appimage_filename
     # Ensure appimage is copied to appdir_bindir.
     downloaded_file = utils.get_downloaded_file_path(app.conf.download_dir, appimage_filename) #noqa: E501
     if downloaded_file is None:

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -225,10 +225,12 @@ def get_wine_options(app: App) -> List[str]:  # noqa: E501
 
     reccomended_appimage = f"{app.conf.installer_binary_dir}/{app.conf.wine_appimage_recommended_file_name}" # noqa: E501
 
+    if reccomended_appimage in appimages:
+        appimages.remove(reccomended_appimage)
+
     # Add AppImages to list
+    wine_binary_options.append(reccomended_appimage)
     wine_binary_options.extend(appimages)
-    if reccomended_appimage not in wine_binary_options:
-        wine_binary_options.append(reccomended_appimage)
 
     sorted_binaries = sorted(list(set(binaries)))
     logging.debug(f"{sorted_binaries=}")

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -223,13 +223,13 @@ def get_wine_options(app: App) -> List[str]:  # noqa: E501
     logging.debug(f"{binaries=}")
     wine_binary_options = []
 
-    reccomended_appimage = f"{app.conf.installer_binary_dir}/{app.conf.wine_appimage_recommended_file_name}" # noqa: E501
+    recomended_appimage = f"{app.conf.installer_binary_dir}/{app.conf.wine_appimage_recommended_file_name}" # noqa: E501
 
-    if reccomended_appimage in appimages:
-        appimages.remove(reccomended_appimage)
+    if recomended_appimage in appimages:
+        appimages.remove(recomended_appimage)
 
     # Add AppImages to list
-    wine_binary_options.append(reccomended_appimage)
+    wine_binary_options.append(recomended_appimage)
     wine_binary_options.extend(appimages)
 
     sorted_binaries = sorted(list(set(binaries)))


### PR DESCRIPTION
Fixes issue where new appimage would be downloaded with the wrong name and moves the recommended appimage to the top of the list

Reproduction:
- install when there is an older recommended appimage
- delete LogosBible10 folder
- attempt install again

Expected behavior: new appimage downloads with correct name

Actual behavior: appimage downloads with the old name