### PR TITLE
Fix AppImage update procedure in GUI

### DIFF
--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -478,7 +478,7 @@ class ControlWindow(GuiApp):
             command=self.update_to_latest_lli_release
         )
         self.gui.latest_appimage_button.config(
-            command=self.update_to_latest_appimage
+            command=self.start_appimage_update
         )
         self.gui.set_appimage_button.config(command=self.set_appimage)
         self.gui.get_winetricks_button.config(command=self.get_winetricks)
@@ -579,9 +579,17 @@ class ControlWindow(GuiApp):
         utils.set_appimage_symlink(self)
         self.update_latest_appimage_button()
 
-    def update_to_latest_appimage(self, evt=None):
+    def start_appimage_update(self):
         self.status("Updating to latest AppImage…")
-        self.start_thread(self.set_appimage_symlink)
+        self.gui.latest_appimage_button.state(['disabled'])
+        evt = '<<AppImageUpdateDone>>'
+        self.root.bind(evt, self.update_latest_appimage_button)
+        self.start_thread(self.update_to_latest_appimage, evt=evt)
+
+    def update_to_latest_appimage(self, evt=None):
+        utils.update_to_latest_recommended_appimage(self)
+        self.root.event_generate(evt)
+
 
     def set_appimage(self, evt=None):
         # TODO: Separate as advanced feature.

--- a/ou_dedetai/network.py
+++ b/ou_dedetai/network.py
@@ -521,7 +521,7 @@ def _get_latest_release_data(repository) -> SoftwareReleaseInfo:
         download_url=download_url
     )
 
-def dwonload_recommended_appimage(app: App):
+def download_recommended_appimage(app: App):
     wine64_appimage_full_filename = Path(app.conf.wine_appimage_recommended_file_name)  # noqa: E501
     dest_path = Path(app.conf.installer_binary_dir) / wine64_appimage_full_filename
     if dest_path.is_file():

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -18,7 +18,7 @@ import sys
 import tarfile
 import time
 from ou_dedetai.app import App
-from packaging import version
+from packaging.version import Version
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -365,16 +365,16 @@ class VersionComparison(enum.Enum):
 
 
 def compare_logos_linux_installer_version(app: App) -> Optional[VersionComparison]:
-    current = constants.LLI_CURRENT_VERSION
-    latest = app.conf.app_latest_version
+    current = Version(constants.LLI_CURRENT_VERSION)
+    latest = Version(app.conf.app_latest_version)
 
-    if version.parse(current) < version.parse(latest):
+    if current < latest:
         # Current release is older than recommended.
         output = VersionComparison.OUT_OF_DATE
-    elif version.parse(current) > version.parse(latest):
+    elif current > latest:
         # Installed version is custom.
         output = VersionComparison.DEVELOPMENT
-    elif version.parse(current) == version.parse(latest):
+    elif current == latest:
         # Current release is latest.
         output = VersionComparison.UP_TO_DATE
 
@@ -388,10 +388,10 @@ def compare_recommended_appimage_version(app: App):
     wine_exe_path = app.conf.wine_binary
     wine_release, error_message = wine.get_wine_release(wine_exe_path)
     if wine_release is not None and wine_release is not False:
-        current_version = f"{wine_release.major}.{wine_release.minor}"
+        current_version = Version(f"{wine_release.major}.{wine_release.minor}")
         logging.debug(f"Current wine release: {current_version}")
 
-        recommended_version = app.conf.wine_appimage_recommended_version
+        recommended_version = Version(app.conf.wine_appimage_recommended_version)
         logging.debug(f"Recommended wine release: {recommended_version}")
         if current_version < recommended_version:
             # Current release is older than recommended.

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -604,6 +604,7 @@ def update_to_latest_recommended_appimage(app: App):
     app.conf.wine_appimage_path = Path(app.conf.wine_appimage_recommended_file_name)  # noqa: E501
     status, _ = compare_recommended_appimage_version(app)
     if status == 0:
+        # TODO: Consider also removing old appimage from install dir. 
         set_appimage_symlink(app)
     elif status == 1:
         logging.debug("The AppImage is already set to the latest recommended.")

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -568,7 +568,7 @@ def set_appimage_symlink(app: App):
     if appimage_file_path.name == app.conf.wine_appimage_recommended_file_name:  # noqa: E501
         # Default case.
         # This saves in the install binary dir
-        network.dwonload_recommended_appimage(app)
+        network.download_recommended_appimage(app)
     else:
         # Verify user-selected AppImage.
         if not check_appimage(appimage_file_path):


### PR DESCRIPTION
Fix #273

Use `packaging.version.Version` to compare version numbers, which allows for `major.minor.hotfix` format, as well as `major.minor` format, and is in other ways more flexible than integer or float comparisons.