### PR TITLE
fix: convert MST file to windows path before use (#286)

### DIFF
--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -293,14 +293,6 @@ def ensure_product_installed(app: App):
     app.conf._installed_faithlife_product_release = None
 
     # Clean up temp files, etc.
-    mst_destination = Path(app.conf.install_dir) / "data/wine64_bottle/drive_c/LogosStubFailOK.mst" #noqa E501
-    if mst_destination and mst_destination.is_file():
-        try:
-            mst_destination.unlink()
-            logging.debug(f"Deleted MST file: {mst_destination}")
-        except Exception as e:
-            logging.warning(f"Could not delete MST file: {e}")
-            
     utils.clean_all()
 
     logging.debug(f"> {app.conf.logos_exe=}")


### PR DESCRIPTION
This fixes #286. It seems the appimage would work fine with the hard-coded windows path `C:\LogosStubFailOK.mst`, but this was failing when using system wine. But using `winepath -w` to convert the original MST file path to a winepath, and ensuring that the path is not quoted, succeeds. In fact, it's probably the lack of quotes that solves the problem, but this also adds a simplification in not needing to copy the MST file into the WINEPREFIX before using it.