### PR TITLE
fix: remove pyinstaller from LD_LIBRARY_PATH when shelling out

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -233,6 +233,9 @@ class EphemeralConfiguration:
     
     Accepted values: tk (GUI), curses (TUI), cli (CLI)"""
 
+    wine_args: Optional[list[str]] = None
+    """Arguments when running wine from cli"""
+
     terminal_app_prefer_dialog: Optional[bool] = None
 
     # Start of values just set via cli arg

--- a/ou_dedetai/control.py
+++ b/ou_dedetai/control.py
@@ -7,7 +7,6 @@ import logging
 import queue
 import os
 import shutil
-import subprocess
 import time
 from pathlib import Path
 
@@ -18,7 +17,7 @@ from . import utils
 
 
 def edit_file(config_file: str):
-    subprocess.Popen(['xdg-open', config_file])
+    system.run_command(['xdg-open', config_file])
 
 
 def backup(app: App):

--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -97,6 +97,9 @@ class LogosManager:
             except Exception as e:
                 # pass
                 logging.error(e)
+        else:
+            # Useful if the install directory got deleted while executing
+            self.logos_state = State.STOPPED
 
     def start(self):
         self.logos_state = State.STARTING

--- a/ou_dedetai/wine.py
+++ b/ou_dedetai/wine.py
@@ -1,9 +1,7 @@
 from dataclasses import dataclass
 import logging
 import os
-import re
 import shutil
-import signal
 import subprocess
 from pathlib import Path
 import tempfile
@@ -82,16 +80,12 @@ def get_wine_release(binary: str) -> tuple[Optional[WineRelease], str]:
         version = wine_version.lstrip('wine-')
         logging.debug(f"Wine branch of {binary}: {branch}")
 
-        if branch is not None:
-            ver_major = int(version.split('.')[0].lstrip('wine-'))  # remove 'wine-'
-            ver_minor_str = version.split('.')[1]
-            # In the case the version is an rc like wine-10.0-rc5
-            if '-' in ver_minor_str:
-                ver_minor_str = ver_minor_str.split("-")[0]
-            ver_minor = int(ver_minor_str)
-        else:
-            ver_major = 0
-            ver_minor = 0
+        ver_major = int(version.split('.')[0].lstrip('wine-'))  # remove 'wine-'
+        ver_minor_str = version.split('.')[1]
+        # In the case the version is an rc like wine-10.0-rc5
+        if '-' in ver_minor_str:
+            ver_minor_str = ver_minor_str.split("-")[0]
+        ver_minor = int(ver_minor_str)
 
         wine_release = WineRelease(ver_major, ver_minor, branch)
         logging.debug(f"Wine release of {binary}: {str(wine_release)}")


### PR DESCRIPTION
Fixes: #292 #143 #236

Didn't test:
- alpine

Tested:
- user that was able to reproduce #292 tested and it works for them
- running integration.run_cmd(["env") from a pyinstaller binary (with and with LD_LIBRARY_PATH set), observed LD_LIBRARY_PATH did not include tmpdir
- running system.run_command(["env") from a pyinstaller binary (with and with LD_LIBRARY_PATH set), observed LD_LIBRARY_PATH did not include tmpdir
- running system.run_command(["env") from a pyinstaller binary (without LD_LIBRARY_PATH set), observed LD_LIBRARY_PATH was not set
- clean install & run - login page showed successfully (install procedure calls popen_command, and run_command)
- built pyinstaller binary and ran on fedora 40 doing a clean install via TUI. login screen shown!
- built pyinstaller binary and ran on arch doing a clean install via TUI, after creating a Downloads folder (which isn't created by default on arch (tracking that [here](https://github.com/FaithLife-Community/LogosLinuxInstaller/issues/237#issuecomment-2638329619))). login screen shown!