### PR TITLE
fix: fix setting tui color scheme

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -325,7 +325,7 @@ class PersistentConfiguration:
     wine_binary_code: Optional[str] = None
     backup_dir: Optional[str] = None
 
-    # Color to use in curses. Either "Logos", "Light", or "Dark"
+    # Color to use in curses. Either "System", "Logos", "Light", or "Dark"
     curses_color_scheme: str = "Logos"
     # Faithlife's release channel. Either "stable" or "beta"
     faithlife_product_release_channel: str = "stable"
@@ -502,7 +502,7 @@ class Config:
     _wine_appimage_files: Optional[list[str]] = None
 
     # Start constants
-    _curses_color_scheme_valid_values = ["Light", "Dark", "Logos"]
+    _curses_color_scheme_valid_values = ["System", "Light", "Dark", "Logos"]
 
     # Singleton logic, this enforces that only one config object exists at a time.
     def __new__(cls, *args, **kwargs) -> "Config":
@@ -926,7 +926,7 @@ class Config:
     def curses_color_scheme(self) -> str:
         """Color for the curses dialog
         
-        returns one of: Logos, Light or Dark"""
+        returns one of: System, Logos, Light or Dark"""
         return self._raw.curses_color_scheme
 
     @curses_color_scheme.setter

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -326,7 +326,7 @@ class PersistentConfiguration:
     backup_dir: Optional[str] = None
 
     # Color to use in curses. Either "Logos", "Light", or "Dark"
-    curses_colors: str = "Logos"
+    curses_color_scheme: str = "Logos"
     # Faithlife's release channel. Either "stable" or "beta"
     faithlife_product_release_channel: str = "stable"
     # The Installer's release channel. Either "stable" or "beta"
@@ -385,7 +385,7 @@ class PersistentConfiguration:
         return PersistentConfiguration(
             faithlife_product=legacy.FLPRODUCT,
             backup_dir=legacy.BACKUPDIR,
-            curses_colors=legacy.curses_colors or 'Logos',
+            curses_color_scheme=legacy.curses_colors,
             faithlife_product_release=legacy.TARGET_RELEASE_VERSION,
             faithlife_product_release_channel=legacy.logos_release_channel or 'stable',
             faithlife_product_version=legacy.TARGETVERSION,
@@ -502,7 +502,7 @@ class Config:
     _wine_appimage_files: Optional[list[str]] = None
 
     # Start constants
-    _curses_colors_valid_values = ["Light", "Dark", "Logos"]
+    _curses_color_scheme_valid_values = ["Light", "Dark", "Logos"]
 
     # Singleton logic, this enforces that only one config object exists at a time.
     def __new__(cls, *args, **kwargs) -> "Config":
@@ -923,24 +923,28 @@ class Config:
         return output
     
     @property
-    def curses_colors(self) -> str:
+    def curses_color_scheme(self) -> str:
         """Color for the curses dialog
         
         returns one of: Logos, Light or Dark"""
-        return self._raw.curses_colors
+        return self._raw.curses_color_scheme
 
-    @curses_colors.setter
-    def curses_colors(self, value: str):
-        if value not in self._curses_colors_valid_values:
-            raise ValueError(f"Invalid curses theme, expected one of: {", ".join(self._curses_colors_valid_values)} but got: {value}") # noqa: E501
-        self._raw.curses_colors = value
+    @curses_color_scheme.setter
+    def curses_color_scheme(self, value: str):
+        if value is None:
+            value = "Logos"
+        if value not in self._curses_color_scheme_valid_values:
+            raise ValueError(f"Invalid curses theme, expected one of: {", ".join(self._curses_color_scheme_valid_values)} but got: {value}") # noqa: E501
+        self._raw.curses_color_scheme = value
         self._write()
     
     def cycle_curses_color_scheme(self):
-        new_index = self._curses_colors_valid_values.index(self.curses_colors) + 1
-        if new_index == len(self._curses_colors_valid_values):
+        if self.curses_color_scheme is None:
+            self.curses_color_scheme = "Logos"
+        new_index = self._curses_color_scheme_valid_values.index(self.curses_color_scheme) + 1
+        if new_index == len(self._curses_color_scheme_valid_values):
             new_index = 0
-        self.curses_colors = self._curses_colors_valid_values[new_index]
+        self.curses_color_scheme = self._curses_color_scheme_valid_values[new_index]
 
     @property
     def logos_exe(self) -> Optional[str]:

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -326,7 +326,7 @@ class PersistentConfiguration:
     backup_dir: Optional[str] = None
 
     # Color to use in curses. Either "System", "Logos", "Light", or "Dark"
-    curses_color_scheme: str = "Logos"
+    curses_color_scheme: Optional[str] = None
     # Faithlife's release channel. Either "stable" or "beta"
     faithlife_product_release_channel: str = "stable"
     # The Installer's release channel. Either "stable" or "beta"
@@ -927,21 +927,17 @@ class Config:
         """Color for the curses dialog
         
         returns one of: System, Logos, Light or Dark"""
-        return self._raw.curses_color_scheme
+        return self._raw.curses_color_scheme or 'Logos'
 
     @curses_color_scheme.setter
-    def curses_color_scheme(self, value: str):
-        if value is None:
-            value = "Logos"
-        if value not in self._curses_color_scheme_valid_values:
+    def curses_color_scheme(self, value: Optional[str]):
+        if value is not None and value not in self._curses_color_scheme_valid_values:
             raise ValueError(f"Invalid curses theme, expected one of: {", ".join(self._curses_color_scheme_valid_values)} but got: {value}") # noqa: E501
         self._raw.curses_color_scheme = value
         self._write()
     
     def cycle_curses_color_scheme(self):
-        if self.curses_color_scheme is None:
-            self.curses_color_scheme = "Logos"
-        new_index = self._curses_color_scheme_valid_values.index(self.curses_color_scheme) + 1
+        new_index = self._curses_color_scheme_valid_values.index(self.curses_color_scheme) + 1 # noqa: E501
         if new_index == len(self._curses_color_scheme_valid_values):
             new_index = 0
         self.curses_color_scheme = self._curses_color_scheme_valid_values[new_index]

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -228,21 +228,27 @@ class TUI(App):
         curses.init_color(curses.COLOR_BLUE, 0, 510, 1000)  # Logos Blue
         curses.init_color(curses.COLOR_CYAN, 906, 906, 906)  # Logos Gray
         curses.init_color(curses.COLOR_WHITE, 988, 988, 988)  # Logos White
-        curses.init_pair(1, curses.COLOR_BLUE, curses.COLOR_CYAN)
+        curses.init_pair(1, -1, -1)  # System
         curses.init_pair(2, curses.COLOR_BLUE, curses.COLOR_WHITE)
         curses.init_pair(3, curses.COLOR_CYAN, curses.COLOR_BLUE)
-        curses.init_pair(4, curses.COLOR_WHITE, curses.COLOR_BLUE)
+        curses.init_pair(4, curses.COLOR_WHITE, curses.COLOR_BLUE)  # Logos
         curses.init_pair(5, curses.COLOR_BLACK, curses.COLOR_BLUE)
-        curses.init_pair(6, curses.COLOR_BLACK, curses.COLOR_WHITE)
-        curses.init_pair(7, curses.COLOR_WHITE, curses.COLOR_BLACK)
+        curses.init_pair(6, curses.COLOR_BLACK, curses.COLOR_WHITE)  # Light
+        curses.init_pair(7, curses.COLOR_WHITE, curses.COLOR_BLACK)  # Dark
 
     def set_curses_color_scheme(self):
-        if self.conf.curses_color_scheme == "Logos":
-            self.stdscr.bkgd(" ", curses.color_pair(3))
+        if self.conf.curses_color_scheme == "System":
+            self.stdscr.bkgd(" ", curses.color_pair(1))
             if self.main_window:
-                self.main_window.bkgd(" ", curses.color_pair(3))
+                self.main_window.bkgd(" ", curses.color_pair(1))
             if self.menu_window:
-                self.menu_window.bkgd(" ", curses.color_pair(3))
+                self.menu_window.bkgd(" ", curses.color_pair(1))
+        elif self.conf.curses_color_scheme == "Logos":
+            self.stdscr.bkgd(" ", curses.color_pair(4))
+            if self.main_window:
+                self.main_window.bkgd(" ", curses.color_pair(4))
+            if self.menu_window:
+                self.menu_window.bkgd(" ", curses.color_pair(4))
         elif self.conf.curses_color_scheme == "Light":
             self.stdscr.bkgd(" ", curses.color_pair(6))
             if self.main_window:

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -236,20 +236,20 @@ class TUI(App):
         curses.init_pair(6, curses.COLOR_BLACK, curses.COLOR_WHITE)
         curses.init_pair(7, curses.COLOR_WHITE, curses.COLOR_BLACK)
 
-    def set_curses_colors(self):
-        if self.conf.curses_colors == "Logos":
+    def set_curses_color_scheme(self):
+        if self.conf.curses_color_scheme == "Logos":
             self.stdscr.bkgd(" ", curses.color_pair(3))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(3))
             if self.menu_window:
                 self.menu_window.bkgd(" ", curses.color_pair(3))
-        elif self.conf.curses_colors == "Light":
+        elif self.conf.curses_color_scheme == "Light":
             self.stdscr.bkgd(" ", curses.color_pair(6))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(6))
             if self.menu_window:
                 self.menu_window.bkgd(" ", curses.color_pair(6))
-        elif self.conf.curses_colors == "Dark":
+        elif self.conf.curses_color_scheme == "Dark":
             self.stdscr.bkgd(" ", curses.color_pair(7))
             if self.main_window:
                 self.main_window.bkgd(" ", curses.color_pair(7))
@@ -287,7 +287,7 @@ class TUI(App):
         try:
             if curses.has_colors():
                 self.set_curses_style()
-                self.set_curses_colors()
+                self.set_curses_color_scheme()
 
             curses.curs_set(0)
             curses.noecho()
@@ -836,7 +836,7 @@ class TUI(App):
 
     def _config_update_hook(self):
         self.update_main_window_contents()
-        self.set_curses_colors()
+        self.set_curses_color_scheme()
         self.set_title()
 
     # def get_password(self, dialog):


### PR DESCRIPTION
Fixes #259.

There were two issues:

- the legacy config value was wiping out the new config value
- the config's init function, in the call to the legacy config, was setting a default value, thus overriding reading the config

To fix these:

- I changed the tui color scheme variable name to differentiate it
- I removed the setting of the default value
- I checked for a None value, which is coming from the legacy config

---

To remove the None check, a default value needs to be established, but setting the default value in the legacy config is causing an existing config's set color scheme to be ignored in favor of the default.

---

This PR also fixes the Logos color scheme: its value was improperly set.

This PR also adds the System color scheme.

---

This needs further work though as sometimes the event is not cleared, causing #278.