### PR TITLE
fix: TUI color scheme cycle hang

### DIFF
--- a/ou_dedetai/logos.py
+++ b/ou_dedetai/logos.py
@@ -131,11 +131,8 @@ class LogosManager:
             if reason is not None:
                 logging.debug(f"Warning: Wine Check: {reason}")
             wine.wineserver_kill(self.app)
-            app = self.app
-            from ou_dedetai.gui_app import GuiApp
-            if not isinstance(self.app, GuiApp):
-                # Don't send "Running" message to GUI b/c it never clears.
-                app.status(f"Running {self.app.conf.faithlife_product}…")
+            # Don't send "Running" message to GUI b/c it never clears.
+            logging.info(f"Running {self.app.conf.faithlife_product}…")
             self.app.start_thread(run_logos, daemon_bool=False)
             # NOTE: The following code would keep the CLI open while running
             # Logos, but since wine logging is sent directly to wine.log,

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -503,6 +503,8 @@ class TUI(App):
         self.tui_screens = []
         self.reset_screen()
         self.menu_screen.choice = "Processing"
+        # Reset running state of main menu so it can submit again.
+        self.menu_screen.running = 0
         self.choice_q.put("Return to Main Menu")
 
     def main_menu_select(self, choice):

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -538,12 +538,10 @@ class TUI(App):
             self.reset_screen()
             self.logos.start()
             self.menu_screen.set_options(self.set_tui_menu_options())
-            # XXX: this used to "switch screens" here. Does it need to?
         elif self.conf._raw.faithlife_product and choice == f"Stop {self.conf.faithlife_product}": #noqa: E501
             self.reset_screen()
             self.logos.stop()
             self.menu_screen.set_options(self.set_tui_menu_options())
-            # XXX: this used to "switch screens" here. Does it need to?
         elif choice == "Run Indexing":
             self.active_screen.running = 0
             self.active_screen.choice = "Processing"


### PR DESCRIPTION
Fix: #278

remove unneeded TUI queues
also removed a clear/refresh in update_main_window_contents that may been the race condition we were looking for. This is done in draw. It renders correctly

Tested:
- Clean install of Logos and run
- changing color scheme over and over again
- navigating into utilities menu and back again
- resizing screen super small (both horizontal and vertical), screen to small was shown