### PR TITLE
feat: add nix-shell

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -624,9 +624,10 @@ class Config:
             # Install Dir has the name of the product and it's version. Reset it too
             if self._overrides.install_dir is None:
                 self._raw.install_dir = None
-            # Wine is dependent on the product/version selected
-            self._raw.wine_binary = None
-            self._raw.wine_binary_code = None
+            # While different versions have different wine version requirements,
+            # In order to support WINE_EXE we shouldn't clobber here.
+            # self._raw.wine_binary = None
+            # self._raw.wine_binary_code = None
 
             self._write()
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,28 @@
+let
+  # We pin to a specific nixpkgs commit for reproducibility.
+  # Last updated: 2025-02-10. Check for new commits at https://status.nixos.org.
+  pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/a45fa362d887f4d4a7157d95c28ca9ce2899b70e.tar.gz") {};
+  unstable_pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/fa35a3c8e17a3de613240fea68f876e5b4896aec.tar.gz") {};
+ 
+in pkgs.mkShell {
+  packages = [
+    (pkgs.python312.withPackages (python-pkgs: with python-pkgs; [
+      # These packages may fall out of date with those in pyproject.toml
+      # See pyproject.toml for the source of truth
+      distro
+      packaging
+      psutil
+      pythondialog
+      inotify
+      requests
+      tkinter
+    ]))
+    unstable_pkgs.wineWowPackages.full
+  ];
+  shellHook = ''
+    export WINE_EXE="`which wine`"
+    export SKIP_DEPENDENCIES=True
+    export WINEBIN_CODE=System
+    echo "Run with: python3.12 -m ou_dedetai.main"
+  '';
+}


### PR DESCRIPTION
This python package list should not be considered up-to-date, see pyproject.toml for the latest.

Sets all envs needed for running on NixOS
Also fixed bug where WINE_EXE wasn't respected

on nix simply run `nix-shell` and it will download the python dependencies as well as wine needed for Logos on NixOS

Tested:
- Install on NixOS (TUI)
- Noticed that the TUI "Run Logos" button didn't work the first time, had to re-launch OD
- Noticed after logging in, when hitting "Continue" after selecting Download All Resources, Logos crashed, but recovered after launching again

Didn't see any indication the above bugs were NixOS specific and they were easily recoverable.