### PR TITLE
fix: bad path leading to oudedetai running installer every time

### DIFF
--- a/snap/bin/run.sh
+++ b/snap/bin/run.sh
@@ -12,7 +12,7 @@ echo "Starting $FLPRODUCT"
 export TARGETVERSION="10"
 
 # Ensure Faithlife app is installed.
-app_exe="$(find "${INSTALLDIR}/wine64_bottle" -wholename "*${FLPRODUCT}/${FLPRODUCT}.exe" 2>/dev/null)"
+app_exe="$(find "${INSTALLDIR}/data/wine64_bottle" -wholename "*${FLPRODUCT}/${FLPRODUCT}.exe" 2>/dev/null)"
 if [[ -z $app_exe ]]; then
     oudedetai --install-app --assume-yes $@
     ec=$?


### PR DESCRIPTION
The path used to search for the installed app was incorrect, which triggered installation on every run. Thankfully our installer verifies each step along the way, so nothing actually gets installed again. But this short-circuits running unnecessary code.