### PR TITLE
fix: Alpine installs

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -482,7 +482,7 @@ def get_package_manager() -> PackageManager | None:
         packages = (
             "bash bash-completion "  # bash support
             "gcompat "  # musl to glibc
-            "fuse-common fuse "  # appimages
+            "fuse-common fuse fuse3 "  # appimages
             "wget curl "  # network
             "samba sed grep gawk bash bash-completion "  # other
         )

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -719,12 +719,12 @@ def postinstall_dependencies_steamos(superuser_command: str):
 def postinstall_dependencies_alpine(superuser_command: str):
     user = os.getlogin()
     command = [
-        superuser_command, "modprobe", "fuse", "&&",
-        superuser_command, "rc-update", "add", "fuse", "boot", "&&",
-        superuser_command, "sed", "-i", "'s/#user_allow_other/user_allow_other/g'", "/etc/fuse.conf", "&&", #noqa: E501
-        superuser_command, "addgroup", "fuse", "&&",
-        superuser_command, "adduser", f"{user}", "fuse", "&&",
-        superuser_command, "rc-service", "fuse", "restart",
+        superuser_command, "modprobe ", "fuse ", "&& ",
+        superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-update add fuse boot ", "&& ",
+        superuser_command, "sed ", "-i ", "'s/#user_allow_other/user_allow_other/g' ", "/etc/fuse.conf ", "&& ", #noqa: E501
+        superuser_command, "addgroup ", "fuse ", "&& ",
+        superuser_command, "adduser ", f"{user} ", "fuse ", "&& ",
+        superuser_command, "bash ", "-c ", "if \( ! rc-service -e fuse ); then rc-service fuse restart ", "&& ",
     ]
     return command
 

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -480,11 +480,11 @@ def get_package_manager() -> PackageManager | None:
         query_command = ["apk", "list", "-i"]
         query_prefix = ''
         packages = (
-            "bash bash-completion"  # bash support
-            "gcompat"  # musl to glibc
-            "fuse-common fuse"  # appimages
-            "wget curl"  # network
-            "samba sed grep gawk bash bash-completion"  # other
+            "bash bash-completion "  # bash support
+            "gcompat "  # musl to glibc
+            "fuse-common fuse "  # appimages
+            "wget curl "  # network
+            "samba sed grep gawk bash bash-completion "  # other
         )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('pamac') is not None:  # manjaro


### PR DESCRIPTION
Fixes #294.

Work in Progress.

The issue here appears to be that the Wine AppImage was not made with muslc, and so thus it won't run even if everything else is up and running.

Now when running the appimage, it says it can't open the wine commands. I believe that is for the above reason.