### PR TITLE
chore: remove Logos 9 support

### DIFF
--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -612,9 +612,11 @@ class Config:
     def faithlife_product_version(self) -> str:
         if self._overrides.faithlife_product_version is not None:
             return self._overrides.faithlife_product_version
-        question = f"Which version of {self.faithlife_product} should the script install?: "  # noqa: E501
-        options = constants.FAITHLIFE_PRODUCT_VERSIONS
-        return self._ask_if_not_found("faithlife_product_version", question, options, []) # noqa: E501
+        if self.conf.faithlife_product_version is None:
+            return "10"  # Keep following for historical reasons.
+        #question = f"Which version of {self.faithlife_product} should the script install?: "  # noqa: E501
+        #options = constants.FAITHLIFE_PRODUCT_VERSIONS
+        #return self._ask_if_not_found("faithlife_product_version", question, options, []) # noqa: E501
 
     @faithlife_product_version.setter
     def faithlife_product_version(self, value: Optional[str]):

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -81,8 +81,6 @@ DEFAULT_LOG_LEVEL = logging.WARNING
 LOGOS_BLUE = '#0082FF'
 LOGOS_GRAY = '#E7E7E7'
 LOGOS_WHITE = '#FCFCFC'
-LOGOS9_WINE64_BOTTLE_TARGZ_NAME = "wine64_bottle.tar.gz"
-LOGOS9_WINE64_BOTTLE_TARGZ_URL = f"https://github.com/ferion11/wine64_bottle_dotnet/releases/download/v5.11b/{LOGOS9_WINE64_BOTTLE_TARGZ_NAME}"  # noqa: E501
 PID_FILE = f'/tmp/{BINARY_NAME}.pid'
 
 FAITHLIFE_PRODUCTS = ["Logos", "Verbum"]

--- a/ou_dedetai/gui.py
+++ b/ou_dedetai/gui.py
@@ -77,7 +77,8 @@ class InstallerGui(Frame):
             textvariable=self.versionvar
         )
         self.version_dropdown.state(['readonly'])
-        self.version_dropdown['values'] = ('9', '10')
+        #TODO: Remove this dropdown
+        self.version_dropdown['values'] = ('10')
         self.versionvar.set(self.version_dropdown['values'][1])
         if app.conf._raw.faithlife_product_version in self.version_dropdown['values']:
             self.version_dropdown.set(app.conf._raw.faithlife_product_version)

--- a/ou_dedetai/installer.py
+++ b/ou_dedetai/installer.py
@@ -113,38 +113,9 @@ def ensure_wine_executables(app: App):
     logging.debug(f"> {app.conf.wineserver_binary=}")
 
 
-def ensure_premade_winebottle_download(app: App):
-    app.installer_step_count += 1
-    ensure_wine_executables(app=app)
-    app.installer_step += 1
-    if app.conf.faithlife_product_version != '9':
-        return
-    app.status(f"Ensuring {constants.LOGOS9_WINE64_BOTTLE_TARGZ_NAME} bottle is downloaded…")  # noqa: E501
-
-    downloaded_file = utils.get_downloaded_file_path(app.conf.download_dir, constants.LOGOS9_WINE64_BOTTLE_TARGZ_NAME)  # noqa: E501
-    if not downloaded_file:
-        downloaded_file = Path(app.conf.download_dir) / app.conf.faithlife_installer_name #noqa: E501
-    network.logos_reuse_download(
-        constants.LOGOS9_WINE64_BOTTLE_TARGZ_URL,
-        constants.LOGOS9_WINE64_BOTTLE_TARGZ_NAME,
-        app.conf.download_dir,
-        app=app,
-    )
-    # Install bottle.
-    bottle = Path(app.conf.wine_prefix)
-    if not bottle.is_dir():
-        # FIXME: this code seems to be logos 9 specific, why is it here?
-        utils.install_premade_wine_bottle(
-            app.conf.download_dir,
-            f"{app.conf.install_dir}/data"
-        )
-
-    logging.debug(f"> '{downloaded_file}' exists?: {Path(downloaded_file).is_file()}")  # noqa: E501
-
-
 def ensure_product_installer_download(app: App):
     app.installer_step_count += 1
-    ensure_premade_winebottle_download(app=app)
+    ensure_wine_executables(app=app)
     app.installer_step += 1
     app.status(f"Ensuring {app.conf.faithlife_product} installer is downloaded…")
 
@@ -176,19 +147,13 @@ def ensure_wineprefix_init(app: App):
     logging.debug(f"{init_file=}")
     if not init_file.is_file():
         logging.debug(f"{init_file} does not exist")
-        if app.conf.faithlife_product_version == '9':
-            utils.install_premade_wine_bottle(
-                app.conf.download_dir,
-                f"{app.conf.install_dir}/data",
-            )
-        else:
-            logging.debug("Initializing wineprefix.")
-            process = wine.initializeWineBottle(app.conf.wine64_binary, app)
-            if process:
-                process.wait()
-            # wine.light_wineserver_wait()
-            wine.wineserver_wait(app)
-            logging.debug("Wine init complete.")
+        logging.debug("Initializing wineprefix.")
+        process = wine.initializeWineBottle(app.conf.wine64_binary, app)
+        if process:
+            process.wait()
+        # wine.light_wineserver_wait()
+        wine.wineserver_wait(app)
+        logging.debug("Wine init complete.")
     logging.debug(f"> {init_file} exists?: {init_file.is_file()}")
 
 

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -386,7 +386,6 @@ class PackageManager:
     query_prefix: str
 
     packages: str
-    logos_9_packages: str
     
     incompatible_packages: str
     # For future expansion:
@@ -407,8 +406,6 @@ def get_package_manager() -> PackageManager | None:
     query_command: list[str]
     query_prefix: str
     packages: str
-    # FIXME: Missing Logos 9 Packages
-    logos_9_packages: str = ""
     incompatible_packages: str
 
     if shutil.which('apt') is not None:  # debian, ubuntu, & derivatives
@@ -440,7 +437,6 @@ def get_package_manager() -> PackageManager | None:
                 "libfuse3-3 "  # appimages
                 "binutils wget winbind "  # wine
             )
-        logos_9_packages = ""  
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('dnf') is not None:  # rhel, fedora
         install_command = ["dnf", "install", "-y"]
@@ -518,7 +514,6 @@ def get_package_manager() -> PackageManager | None:
                 "libva mpg123 v4l-utils "  # video
                 "libxslt sqlite "  # misc
             )
-        logos_9_packages = ""
         incompatible_packages = ""  # appimagelauncher handled separately
     elif os_name == "org.freedesktop.platform":
         # Flatpak
@@ -539,7 +534,6 @@ def get_package_manager() -> PackageManager | None:
         remove=remove_command,
         incompatible_packages=incompatible_packages,
         packages=packages,
-        logos_9_packages=logos_9_packages,
         query_prefix=query_prefix
     )
     logging.debug(f"Package Manager: {output}")
@@ -783,9 +777,6 @@ def install_dependencies(app: App, target_version=10):  # noqa: E501
     package_list = package_manager.packages.split()
 
     bad_package_list = package_manager.incompatible_packages.split()
-
-    if target_version == 9:
-        package_list.extend(package_manager.logos_9_packages.split())
 
     logging.debug("Querying packages…")
     missing_packages = query_packages(

--- a/ou_dedetai/utils.py
+++ b/ou_dedetai/utils.py
@@ -122,12 +122,10 @@ def install_dependencies(app: App):
     if targetversion == 10:
         system.install_dependencies(app, target_version=10)  # noqa: E501
     elif targetversion == 9:
-        system.install_dependencies(
-            app,
-            target_version=9
-        )
+        app.status("Logos 9 not supported.", 100)
+        app.exit("Logos 9 not supported.", False)
     else:
-        logging.error(f"Unknown Target version, expecting 9 or 10 but got: {app.conf.faithlife_product_version}.") #noqa: E501
+        logging.error(f"Unknown Target version, expecting 10 but got: {app.conf.faithlife_product_version}.") #noqa: E501
 
     app.status("Installed dependencies.", 100)
 
@@ -305,13 +303,6 @@ def get_latest_folder(folder_path):
     logging.info(f"Latest folder: {latest}")
     return latest
 
-
-def install_premade_wine_bottle(srcdir, appdir):
-    logging.info(f"Extracting: '{constants.LOGOS9_WINE64_BOTTLE_TARGZ_NAME}' into: {appdir}")  # noqa: E501
-    shutil.unpack_archive(
-        f"{srcdir}/{constants.LOGOS9_WINE64_BOTTLE_TARGZ_NAME}",
-        appdir
-    )
 
 class VersionComparison(enum.Enum):
     OUT_OF_DATE = enum.auto()


### PR DESCRIPTION
Fixes #53.

Removes Logos 9 support. Since the FLPRODUCT version in @ctrlaltf24's abstract class refactor is now acquired through the config, all we need to do is have it return 10 no matter what.

I've left the question in code in order to maintain should we need it in the future. I don't think we will since Logos has moved towards a semi-SaaS model.