### PR TITLE
feat(wip): use wine from extracted appimage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv/
 *.egg-info
 .vscode
 /.flatpak-builder
+/distrobox

--- a/ou_dedetai/cli.py
+++ b/ou_dedetai/cli.py
@@ -107,7 +107,7 @@ class CLI(App):
         self.logos.switch_logging()
 
     def update_latest_appimage(self):
-        utils.update_to_latest_recommended_appimage(self)
+        installer.update_to_latest_wine(self)
 
     def update_self(self):
         utils.update_to_latest_lli_release(self)

--- a/ou_dedetai/config.py
+++ b/ou_dedetai/config.py
@@ -330,11 +330,8 @@ class PersistentConfiguration:
     faithlife_product_logging: Optional[bool] = None
     install_dir: Optional[str] = None
     wine_binary: Optional[str] = None
-    # FIXME: Should this be stored independently of wine_binary
-    # (and potentially get out of sync), or
-    # Should we derive this value from wine_binary?
-    wine_binary_code: Optional[str] = None
-    """This is the type of wine installation used"""
+    # This is where to search for wine
+    # wine_binary_code: Optional[str] = None
     backup_dir: Optional[str] = None
 
     # Color to use in curses. Either "System", "Logos", "Light", or "Dark"
@@ -404,7 +401,7 @@ class PersistentConfiguration:
             install_dir=install_dir,
             app_release_channel=legacy.lli_release_channel or 'stable',
             wine_binary=legacy.WINE_EXE,
-            wine_binary_code=legacy.WINEBIN_CODE,
+            # wine_binary_code=legacy.WINEBIN_CODE,
             faithlife_product_logging=faithlife_product_logging,
             _legacy=legacy
         )
@@ -682,7 +679,9 @@ class Config:
             return self._overrides.faithlife_product_version
         if self._raw.faithlife_product_version is not None:
             return self._raw.faithlife_product_version
-        return "10"
+        # The only version we presently support is 10 - so set it.
+        self.faithlife_product_version = "10"
+        return self.faithlife_product_version
         # Keep following in case we need to prompt for additional versions in the future
         #question = f"Which version of {self.faithlife_product} should the script install?: "
         #options = constants.FAITHLIFE_PRODUCT_VERSIONS
@@ -815,12 +814,13 @@ class Config:
     def _logos_appdata_dir(self) -> Optional[str]:
         """Path to the user's Logos installation under AppData"""
         # We don't want to prompt the user in this function
-        wine_user = self.wine_user
         if (
-            wine_user is None
-            or self._raw.faithlife_product is None
+            self._raw.faithlife_product is None
             or self._raw.install_dir is None
         ):
+            return None
+        wine_user = self.wine_user
+        if wine_user is None:
             return None
         return get_logos_appdata_dir(
             self.wine_prefix,
@@ -871,6 +871,26 @@ class Config:
         return get_wine_prefix_path(self.install_dir)
 
     @property
+    def wine_rootfs(self) -> str:
+        """This path may or may not exist"""
+        return f"{self.install_dir}/{self.wine_rootfs_relative}"
+    
+    @property
+    def wine_rootfs_relative(self) -> str:
+        """This path may or may not exist"""
+        return "wine_rootfs/"
+
+    @property
+    def wine_path_in_rootfs(self) -> str:
+        wine_opt = Path(self.wine_rootfs) / "opt"
+        # Glob on the next folder as it might be wine-staging, or wine-stable, ect.
+        return str(next(wine_opt.glob("wine*")) / "bin" / "wine") #noqa: E501
+
+    @property
+    def is_wine_binary_in_wine_rootfs(self) -> bool:
+        return self.wine_binary.startswith(self.wine_rootfs_relative) or self.wine_binary.startswith(self.wine_rootfs)
+
+    @property
     def wine_binary(self) -> str:
         """Returns absolute path to the wine binary"""
         output = self._raw.wine_binary
@@ -908,6 +928,19 @@ class Config:
     @wine_binary.setter
     def wine_binary(self, value: str):
         """Takes in a path to the wine binary and stores it as relative for storage"""
+        if value in [
+            constants.RECOMMENDED_WINE_APPIMAGE_SIGIL,
+            constants.RECOMMENDED_WINE_TARBALL_SIGIL,
+            constants.UNTESTED_WINE_STABLE_APPIMAGE_SIGIL,
+            constants.UNTESTED_WINE_STAGING_APPIMAGE_SIGIL,
+            constants.UNTESTED_WINE_DEVELOPMENT_APPIMAGE_SIGIL,
+        ]:
+            # We handle this case in the installer.
+            # Don't like how this value (which should only be a path to a wine binary)
+            # can sometimes be a download option - i.e. one that doesn't exist yet.
+            # But that's a problem for another day.
+            pass
+
         # Make the path absolute for comparison
         relative = self._relative_from_install_dir(value)
         # FIXME: consider this, it doesn't work at present as the wine_binary may be an
@@ -919,7 +952,7 @@ class Config:
         if self._raw.wine_binary != relative:
             self._raw.wine_binary = relative
             # Reset dependents
-            self._raw.wine_binary_code = None
+            # self._raw.wine_binary_code = None
             self._overrides.wine_appimage_path = None
             self._wine64_path = None
             self._write()
@@ -938,16 +971,6 @@ class Config:
         if self._wine_appimage_files is None:
             self._wine_appimage_files = utils.find_appimage_files(self.app)
         return self._wine_appimage_files
-
-    @property
-    def wine_binary_code(self) -> str:
-        """Wine binary code.
-        
-        One of: Recommended, AppImage, System, Proton, PlayOnLinux, Custom"""
-        if self._raw.wine_binary_code is None:
-            self._raw.wine_binary_code = utils.get_winebin_code_and_desc(self.app, self.wine_binary)[0]
-            self._write()
-        return self._raw.wine_binary_code
 
     @property
     def wine64_binary(self) -> str:
@@ -1025,9 +1048,6 @@ class Config:
         if self._overrides.wine_appimage_path != value:
             self._overrides.wine_appimage_path = value
             # Reset dependents
-            self._raw.wine_binary_code = None
-            # NOTE: we don't save this persistently, it's assumed
-            # it'll be saved under wine_binary if it's used
 
     @property
     def wine_appimage_link_file_name(self) -> str:
@@ -1036,22 +1056,33 @@ class Config:
         return 'selected_wine.AppImage'
 
     @property
-    def wine_appimage_recommended_url(self) -> str:
-        """URL to recommended appimage.
+    def wine_download_url(self) -> str:
+        """URL to download the specified wine binary
         
         Talks to the network if required"""
-        return self._network.wine_appimage_recommended_url()
+        if self.wine_binary == constants.UNTESTED_WINE_STABLE_APPIMAGE_SIGIL:
+            return self._network.wine_appimage_upstream_url("continuous-stable")
+        elif self.wine_binary == constants.UNTESTED_WINE_STAGING_APPIMAGE_SIGIL:
+            return self._network.wine_appimage_upstream_url("continuous-staging")
+        elif self.wine_binary == constants.UNTESTED_WINE_DEVELOPMENT_APPIMAGE_SIGIL:
+            return self._network.wine_appimage_upstream_url("continuous-devel")
+        elif self.wine_binary == constants.RECOMMENDED_WINE_TARBALL_SIGIL:
+            return self._network.wine_tarball_recommended_url()
+        else:
+            # self.wine_binary == constants.RECOMMENDED_WINE_APPIMAGE_SIGIL
+            return self._network.wine_appimage_recommended_url()
+        
     
     @property
-    def wine_appimage_recommended_file_name(self) -> str:
+    def wine_download_file_name(self) -> str:
         """Returns the file name of the recommended appimage with extension"""
-        return os.path.basename(self.wine_appimage_recommended_url)
+        return os.path.basename(self.wine_download_url)
 
     @property
-    def wine_appimage_recommended_version(self) -> str:
+    def wine_recommended_version(self) -> str:
         # Getting version and branch rely on the filename having this format:
         #   wine-[branch]_[version]-[arch]
-        return self.wine_appimage_recommended_file_name.split('-')[1].split('_')[1]
+        return self.wine_download_file_name.split('-')[1].split('_')[1]
 
     @property
     def wine_dll_overrides(self) -> str:
@@ -1153,7 +1184,12 @@ class Config:
     @property
     def wine_user(self) -> Optional[str]:
         # We don't want to prompt the user for install_dir if it isn't set
-        if not self._raw.install_dir:
+        # or anything that is used in the default install dir
+        if (
+            not self._raw.install_dir
+            or not self._raw.faithlife_product 
+            or not self._raw.faithlife_product_version
+        ):
             return None
         # Cache a successful result (as it goes out to the fs)
         if not self._wine_user:

--- a/ou_dedetai/constants.py
+++ b/ou_dedetai/constants.py
@@ -107,3 +107,11 @@ PROMPT_OPTION_SIGILS = [PROMPT_OPTION_DIRECTORY, PROMPT_OPTION_FILE, PROMPT_OPTI
 
 # String for when a binary is meant to be downloaded later
 DOWNLOAD = "Download"
+
+# Sigils used in conditional logic
+RECOMMENDED_WINE_APPIMAGE_SIGIL="Recommended Appimage"
+# At preset all these files appear statically linked, no need to mess with LD_LIBRARY_PATH
+RECOMMENDED_WINE_TARBALL_SIGIL="Recommended"
+UNTESTED_WINE_STABLE_APPIMAGE_SIGIL="Latest (untested) Appimage from wine stable"
+UNTESTED_WINE_STAGING_APPIMAGE_SIGIL="Latest (untested) Appimage from wine staging"
+UNTESTED_WINE_DEVELOPMENT_APPIMAGE_SIGIL="Latest (untested) Appimage from wine development" # noqa: E501

--- a/ou_dedetai/gui_app.py
+++ b/ou_dedetai/gui_app.py
@@ -618,7 +618,7 @@ class ControlWindow(GuiApp):
         self.start_thread(self.update_to_latest_appimage, evt=evt)
 
     def update_to_latest_appimage(self, evt=None):
-        utils.update_to_latest_recommended_appimage(self)
+        installer.update_to_latest_wine(self)
         self.root.event_generate(evt)
 
     def set_appimage(self, evt=None):
@@ -706,7 +706,7 @@ class ControlWindow(GuiApp):
         if not self.is_installed():
             state = "disabled"
             msg = "Please install first"
-        elif self.conf._raw.wine_binary_code not in ["Recommended", "AppImage", None]:
+        elif self.conf.wine_appimage_path is None:
             state = 'disabled'
             msg = "This button is disabled. The configured install was not created using an AppImage."
             self.gui.set_appimage_button.state(['disabled'])
@@ -715,7 +715,7 @@ class ControlWindow(GuiApp):
                 "This button is disabled. The configured install was not created using an AppImage."
             )
         elif self.conf._raw.wine_binary is not None:
-            status, _ = utils.compare_recommended_appimage_version(self)
+            status, _ = utils.compare_recommended_wine_version(self)
             if status == 0:
                 state = '!disabled'
             elif status == 1:

--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -409,6 +409,9 @@ def get_package_manager() -> PackageManager | None:
     packages: str
     incompatible_packages: str
 
+    # FIXME: consider what to do with appimage dependencies long term - should they be removed?
+    # Moved to a feature flag or something?
+
     if shutil.which('apt') is not None:  # debian, ubuntu, & derivatives
         install_command = ["apt", "install", "-y"]
         download_command = ["apt", "install", "--download-only", "-y"]
@@ -418,7 +421,7 @@ def get_package_manager() -> PackageManager | None:
         # Set default package list.
         packages = (
             "libfuse2 "  # appimages
-            "binutils wget winbind "  # wine
+            "binutils wget winbind libfreetype6 "  # wine
             "p7zip-full cabextract " # winetricks
         )
         # NOTE: Package names changed together for Ubuntu 24+, Debian 13+, and
@@ -525,7 +528,7 @@ def get_package_manager() -> PackageManager | None:
         else:  # arch
             packages = (
                 "fuse2 "  # appimages
-                "binutils libwbclient samba wget "  # wine
+                "binutils libwbclient samba wget freetype2 "  # wine
                 "7zip cabextract " # winetricks (7zip used to be called pzip then p7zip)
                 "openjpeg2 libxcomposite libxinerama "  # display
                 "ocl-icd vulkan-icd-loader "  # hardware
@@ -929,8 +932,7 @@ def ensure_winetricks(
 
     # Symlink if using an appimage
     if (
-        app.conf.wine_binary_code in ["Recommended", "AppImage"]
-        and app.conf.wine_appimage_path is not None
+        app.conf.wine_appimage_path is not None
         and app.conf.wine_appimage_path.exists()
     ):
         winetricks_path.symlink_to(app.conf.wine_appimage_path)

--- a/ou_dedetai/tui_app.py
+++ b/ou_dedetai/tui_app.py
@@ -748,7 +748,7 @@ class TUI(App):
                 self.start_thread(self.do_backup)
             elif choice == "Update to Latest AppImage":
                 self.reset_screen()
-                utils.update_to_latest_recommended_appimage(self)
+                installer.update_to_latest_wine(self)
                 self.go_to_main_menu()
             # This isn't an option in set_utilities_menu_options
             # This code path isn't reachable and isn't tested post-refactor

--- a/ou_dedetai/tui_curses.py
+++ b/ou_dedetai/tui_curses.py
@@ -256,6 +256,7 @@ class MenuDialog(CursesDialog):
                 option = self.app.options[index]
                 if type(option) is list:
                     option_lines = []
+                    # XXX: What's up with this name?
                     wine_binary_code = option[0]
                     if wine_binary_code != "Exit":
                         wine_binary_path = option[1]

--- a/scripts/run_distrobox.sh
+++ b/scripts/run_distrobox.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -x
+
+# docker.io/archlinux/archlinux:latest
+DISTRO=${DISTRO:-debian}
+DISTRO_TAG=${DISTRO_TAG:-12}
+
+CONTAINER_NAME=${CONTAINER_NAME:-oudedetai_${DISTRO}_test}
+
+./scripts/build-binary.sh
+
+# This assumes the backend is podman
+
+podman rm -f ${CONTAINER_NAME}
+distrobox create -Y -i ${DISTRO}:${DISTRO_TAG} -n ${CONTAINER_NAME} --home `pwd`/distrobox/${DISTRO}
+
+# XXX: consider coping the cache for some of the tests
+
+podman cp ./dist/oudedetai ${CONTAINER_NAME}:/bin/
+
+# First install dependencies as root - as the container may not have sudo setup
+distrobox enter --additional-flags "--user root" ${CONTAINER_NAME} -- /bin/oudedetai -I -f -y --i-agree-to-faithlife-terms
+# Uninstall partially to cleanup the config file that was written as root above
+distrobox enter  --additional-flags "--user root" ${CONTAINER_NAME} -- sh -c "chown -R $USER: ~/"
+
+# Then install as user normally
+distrobox enter ${CONTAINER_NAME} -- /bin/oudedetai --install-app -y --i-agree-to-faithlife-terms --verbose
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,7 +47,7 @@ class TestAppUtils(unittest.TestCase):
     @unittest.skip("Needs functional wine binary.")
     def test_compare_recommended_appimage_version(self):
         self.app.conf.wine_appimage_recommended_version = '11'
-        status, msg = utils.compare_recommended_appimage_version(self.app)
+        status, msg = utils.compare_recommended_wine_version(self.app)
         self.assertEqual(status, 0)
 
     def test_die_if_running_nofile(self):


### PR DESCRIPTION
removes wine code logic

switches default to using the tarball of the appimage instead to avoid the fuse dependency
- this doesn't yet work inside of distrobox but does work on my debian host. Not pushing yet as there is clearly something I'm not understanding as to how the appimage gets mounted. I'd prefer if this was a pure binary/LD_Library path manipulation rather than having to use the wrapper from the appimage

begins to start writing ci around distrobox