### PR TITLE
fix: mesa-utils install on debian

### DIFF
--- a/ou_dedetai/system.py
+++ b/ou_dedetai/system.py
@@ -452,7 +452,7 @@ def get_package_manager() -> PackageManager | None:
             "binutils wget winbind "  # wine
             "p7zip-full cabextract " # winetricks
             "xdg-utils " # For xdg-mime needed for custom url scheme registration
-            "mesa-utils"  # verify opengl version
+            "mesa-utils "  # verify opengl version
         )
 
         # Now set the appimage packages, this has changed over time
@@ -551,7 +551,7 @@ def get_package_manager() -> PackageManager | None:
             "curl gawk grep "  # other
             "7zip cabextract "  # winetricks (7zip used to be called p7zip)
             "xdg-utils " # For xdg-mime needed for custom url scheme registration
-            "mesa-utils"  # verify opengl version
+            "mesa-utils "  # verify opengl version
         )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif shutil.which('pacman') is not None:  # arch, steamOS
@@ -573,7 +573,7 @@ def get_package_manager() -> PackageManager | None:
                 "lib32-ncurses ocl-icd lib32-ocl-icd libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 "
                 "gst-plugins-base-libs lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader "
                 "xdg-utils " # For xdg-mime needed for custom url scheme registration
-                "mesa-utils"  # verify opengl version
+                "mesa-utils "  # verify opengl version
             )
         else:  # arch
             packages = (
@@ -586,7 +586,7 @@ def get_package_manager() -> PackageManager | None:
                 "libva mpg123 v4l-utils "  # video
                 "libxslt sqlite "  # misc
                 "xdg-utils " # For xdg-mime needed for custom url scheme registration
-                "mesa-utils"  # verify opengl version
+                "mesa-utils "  # verify opengl version
             )
         incompatible_packages = ""  # appimagelauncher handled separately
     elif os_name == "org.freedesktop.platform":


### PR DESCRIPTION
some platforms have additional logic after the initial package list (such as debian) such that a space needs to be at the end of the package list

Tested:
- Debian 12 ran install with missing packages, installed successfully.